### PR TITLE
シェーダーの呼び出し元を変更

### DIFF
--- a/assets/minecraft/shaders/core/rendertype_beacon_beam.json
+++ b/assets/minecraft/shaders/core/rendertype_beacon_beam.json
@@ -4,8 +4,8 @@
         "srcrgb": "srcalpha",
         "dstrgb": "1-srcalpha"
     },
-    "vertex": "rendertype_beacon_beam",
-    "fragment": "rendertype_beacon_beam",
+    "vertex": "core/rendertype_beacon_beam",
+    "fragment": "core/rendertype_beacon_beam",
     "attributes": [
         "Position",
         "Color",

--- a/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.json
+++ b/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.json
@@ -27,6 +27,7 @@
       { "name": "Light1_Direction", "type": "float", "count": 3, "values": [0.0, 0.0, 0.0] },
       { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
       { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] },
-      { "name": "FogColor", "type": "float", "count": 4, "values": [ 0.0, 0.0, 0.0, 0.0 ] }
+      { "name": "FogColor", "type": "float", "count": 4, "values": [ 0.0, 0.0, 0.0, 0.0 ] },
+      { "name": "FogShape", "type": "int", "count": 1, "values": [ 0 ] }
   ]
 }

--- a/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.json
+++ b/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.json
@@ -4,8 +4,8 @@
       "srcrgb": "srcalpha",
       "dstrgb": "1-srcalpha"
   },
-  "vertex": "rendertype_entity_cutout_no_cull",
-  "fragment": "rendertype_entity_cutout_no_cull",
+  "vertex": "core/rendertype_entity_cutout_no_cull",
+  "fragment": "core/entity",
   "attributes": [
       "Position",
       "Color",

--- a/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.json
+++ b/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.json
@@ -4,8 +4,8 @@
         "srcrgb": "srcalpha",
         "dstrgb": "1-srcalpha"
     },
-    "vertex": "rendertype_entity_translucent_cull",
-    "fragment": "rendertype_entity_translucent_cull",
+    "vertex": "core/rendertype_entity_translucent_cull",
+    "fragment": "core/rendertype_item_entity_translucent_cull",
     "attributes": [
         "Position",
         "Color",


### PR DESCRIPTION
#7 

## 試験環境

Minecraft v1.21.4 (Vanilla)

## 変更内容

以下の２つのシェーダー定義でエラーが出ていた

* rendertype_beacon_beam.json
* rendertype_entity_cutout_no_cull.json

デフォルトで`rendertype_entity_cutout_no_cull(Fragment)`の代わりに`core/entity(Fragment)`を使用するように変更が入っていたので追従、あとはなぜかパスの先頭に`core/`が必要になっていた
とりあえず動くようには修正したが、以下の懸念点があるので要調査

* なぜ`rendertype_entity_translucent_cull`では問題が起きていないのか