### PR TITLE
無限色を汎用的に使えるように拡張

### DIFF
--- a/assets/tusb/items/item/bullet/common_bomb_1.json
+++ b/assets/tusb/items/item/bullet/common_bomb_1.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/common_bomb_1"
+        "model": "tusb:item/bullet/common_bomb_1",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/common_bomb_1_huge.json
+++ b/assets/tusb/items/item/bullet/common_bomb_1_huge.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/common_bomb_1_huge"
+        "model": "tusb:item/bullet/common_bomb_1_huge",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/common_bomb_2.json
+++ b/assets/tusb/items/item/bullet/common_bomb_2.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/common_bomb_2"
+        "model": "tusb:item/bullet/common_bomb_2",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/common_bomb_2_huge.json
+++ b/assets/tusb/items/item/bullet/common_bomb_2_huge.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/common_bomb_2_huge"
+        "model": "tusb:item/bullet/common_bomb_2_huge",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/common_bomb_3.json
+++ b/assets/tusb/items/item/bullet/common_bomb_3.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/common_bomb_3"
+        "model": "tusb:item/bullet/common_bomb_3",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/common_bomb_3_huge.json
+++ b/assets/tusb/items/item/bullet/common_bomb_3_huge.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/common_bomb_3_huge"
+        "model": "tusb:item/bullet/common_bomb_3_huge",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/common_bomb_4.json
+++ b/assets/tusb/items/item/bullet/common_bomb_4.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/common_bomb_4"
+        "model": "tusb:item/bullet/common_bomb_4",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/common_bomb_4_huge.json
+++ b/assets/tusb/items/item/bullet/common_bomb_4_huge.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/common_bomb_4_huge"
+        "model": "tusb:item/bullet/common_bomb_4_huge",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/etc/bone_bullet.json
+++ b/assets/tusb/items/item/bullet/etc/bone_bullet.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/etc/bone_bullet"
+        "model": "tusb:item/bullet/etc/bone_bullet",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/etc/cannon_ball.json
+++ b/assets/tusb/items/item/bullet/etc/cannon_ball.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/etc/cannon_ball"
+        "model": "tusb:item/bullet/etc/cannon_ball",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/etc/color_egg.json
+++ b/assets/tusb/items/item/bullet/etc/color_egg.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/etc/color_egg"
+        "model": "tusb:item/bullet/etc/color_egg",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/etc/color_pearl.json
+++ b/assets/tusb/items/item/bullet/etc/color_pearl.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/etc/color_pearl"
+        "model": "tusb:item/bullet/etc/color_pearl",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/etc/shuriken.json
+++ b/assets/tusb/items/item/bullet/etc/shuriken.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/etc/shuriken"
+        "model": "tusb:item/bullet/etc/shuriken",
+        "tints": [
+            {
+                "type": "custom_model_data",
+                "index": 0,
+                "default": [1.0,1.0,1.0]
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/etc/throwing_knife.json
+++ b/assets/tusb/items/item/bullet/etc/throwing_knife.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/etc/throwing_knife"
+        "model": "tusb:item/bullet/etc/throwing_knife",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/kana_tarai.json
+++ b/assets/tusb/items/item/bullet/kana_tarai.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/kana_tarai"
+        "model": "tusb:item/bullet/kana_tarai",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/laser_shot.json
+++ b/assets/tusb/items/item/bullet/laser_shot.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/laser_shot"
+        "model": "tusb:item/bullet/laser_shot",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/laser_shot_huge.json
+++ b/assets/tusb/items/item/bullet/laser_shot_huge.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/laser_shot_huge"
+        "model": "tusb:item/bullet/laser_shot_huge",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/magnum.json
+++ b/assets/tusb/items/item/bullet/magnum.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/magnum"
+        "model": "tusb:item/bullet/magnum",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/sonic_boom.json
+++ b/assets/tusb/items/item/bullet/sonic_boom.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/sonic_boom"
+        "model": "tusb:item/bullet/sonic_boom",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/stone_bullet.json
+++ b/assets/tusb/items/item/bullet/stone_bullet.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/stone_bullet"
+        "model": "tusb:item/bullet/stone_bullet",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/thorn_iron_ball.json
+++ b/assets/tusb/items/item/bullet/thorn_iron_ball.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/thorn_iron_ball"
+        "model": "tusb:item/bullet/thorn_iron_ball",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/bullet/white_dots.json
+++ b/assets/tusb/items/item/bullet/white_dots.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/bullet/white_dots"
+        "model": "tusb:item/bullet/white_dots",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/angel_ring.json
+++ b/assets/tusb/items/item/mob/angel_ring.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/angel_ring"
+        "model": "tusb:item/mob/angel_ring",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/angel_ring3.json
+++ b/assets/tusb/items/item/mob/angel_ring3.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/angel_ring3"
+        "model": "tusb:item/mob/angel_ring3",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/cannon_body.json
+++ b/assets/tusb/items/item/mob/cannon_body.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/cannon_body"
+        "model": "tusb:item/mob/cannon_body",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/cannon_legs.json
+++ b/assets/tusb/items/item/mob/cannon_legs.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/cannon_legs"
+        "model": "tusb:item/mob/cannon_legs",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/curse/magic_glass.json
+++ b/assets/tusb/items/item/mob/curse/magic_glass.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/curse/magic_glass"
+        "model": "tusb:item/mob/curse/magic_glass",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/curse/magic_stone.json
+++ b/assets/tusb/items/item/mob/curse/magic_stone.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/curse/magic_stone"
+        "model": "tusb:item/mob/curse/magic_stone",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/curse/magic_stone2.json
+++ b/assets/tusb/items/item/mob/curse/magic_stone2.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/curse/magic_stone2"
+        "model": "tusb:item/mob/curse/magic_stone2",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/curse/magic_stone4.json
+++ b/assets/tusb/items/item/mob/curse/magic_stone4.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/curse/magic_stone4"
+        "model": "tusb:item/mob/curse/magic_stone4",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/curse/magic_stone5.json
+++ b/assets/tusb/items/item/mob/curse/magic_stone5.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/curse/magic_stone5"
+        "model": "tusb:item/mob/curse/magic_stone5",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/fire_demon_wait.json
+++ b/assets/tusb/items/item/mob/fire_demon_wait.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/fire_demon_wait"
+        "model": "tusb:item/mob/fire_demon_wait",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/garbage_can_demon.json
+++ b/assets/tusb/items/item/mob/garbage_can_demon.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/garbage_can_demon"
+        "model": "tusb:item/mob/garbage_can_demon",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/heavenly_messenger.json
+++ b/assets/tusb/items/item/mob/heavenly_messenger.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/heavenly_messenger"
+        "model": "tusb:item/mob/heavenly_messenger",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/huge_vase_0.json
+++ b/assets/tusb/items/item/mob/huge_vase_0.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/huge_vase_0"
+        "model": "tusb:item/mob/huge_vase_0",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/large_vase_0.json
+++ b/assets/tusb/items/item/mob/large_vase_0.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/large_vase_0"
+        "model": "tusb:item/mob/large_vase_0",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/large_vase_1.json
+++ b/assets/tusb/items/item/mob/large_vase_1.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/large_vase_1"
+        "model": "tusb:item/mob/large_vase_1",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/large_vase_2.json
+++ b/assets/tusb/items/item/mob/large_vase_2.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/large_vase_2"
+        "model": "tusb:item/mob/large_vase_2",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/magic_cannon_salute_donchian.json
+++ b/assets/tusb/items/item/mob/magic_cannon_salute_donchian.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/magic_cannon_salute_donchian"
+        "model": "tusb:item/mob/magic_cannon_salute_donchian",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/magic_circle.json
+++ b/assets/tusb/items/item/mob/magic_circle.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/magic_circle"
+        "model": "tusb:item/mob/magic_circle",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/magic_fruit_cheriff.json
+++ b/assets/tusb/items/item/mob/magic_fruit_cheriff.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/magic_fruit_cheriff"
+        "model": "tusb:item/mob/magic_fruit_cheriff",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/magic_vegetable_yasaosan.json
+++ b/assets/tusb/items/item/mob/magic_vegetable_yasaosan.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/magic_vegetable_yasaosan"
+        "model": "tusb:item/mob/magic_vegetable_yasaosan",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/nether_gate_of_nothingness.json
+++ b/assets/tusb/items/item/mob/nether_gate_of_nothingness.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/nether_gate_of_nothingness"
+        "model": "tusb:item/mob/nether_gate_of_nothingness",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/petit_blackfall.json
+++ b/assets/tusb/items/item/mob/petit_blackfall.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/petit_blackfall"
+        "model": "tusb:item/mob/petit_blackfall",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/pot_of_chaos.json
+++ b/assets/tusb/items/item/mob/pot_of_chaos.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/pot_of_chaos"
+        "model": "tusb:item/mob/pot_of_chaos",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/predictor.json
+++ b/assets/tusb/items/item/mob/predictor.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/predictor"
+        "model": "tusb:item/mob/predictor",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/thorn_trap_0.json
+++ b/assets/tusb/items/item/mob/thorn_trap_0.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/thorn_trap_0"
+        "model": "tusb:item/mob/thorn_trap_0",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/thorn_trap_1.json
+++ b/assets/tusb/items/item/mob/thorn_trap_1.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/thorn_trap_1"
+        "model": "tusb:item/mob/thorn_trap_1",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/thorn_trap_2.json
+++ b/assets/tusb/items/item/mob/thorn_trap_2.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/thorn_trap_2"
+        "model": "tusb:item/mob/thorn_trap_2",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/tnt.json
+++ b/assets/tusb/items/item/mob/tnt.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/tnt"
+        "model": "tusb:item/mob/tnt",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/trap_hole_0.json
+++ b/assets/tusb/items/item/mob/trap_hole_0.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/trap_hole_0"
+        "model": "tusb:item/mob/trap_hole_0",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/trap_hole_1.json
+++ b/assets/tusb/items/item/mob/trap_hole_1.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/trap_hole_1"
+        "model": "tusb:item/mob/trap_hole_1",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/trap_hole_2.json
+++ b/assets/tusb/items/item/mob/trap_hole_2.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/trap_hole_2"
+        "model": "tusb:item/mob/trap_hole_2",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/mob/wriggling_sand.json
+++ b/assets/tusb/items/item/mob/wriggling_sand.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/mob/wriggling_sand"
+        "model": "tusb:item/mob/wriggling_sand",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/tool/accessory/destructive_warning.json
+++ b/assets/tusb/items/item/tool/accessory/destructive_warning.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/tool/accessory/destructive_warning"
+        "model": "tusb:item/tool/accessory/destructive_warning",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/tool/accessory/magic_square_crystal.json
+++ b/assets/tusb/items/item/tool/accessory/magic_square_crystal.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/tool/accessory/magic_square_crystal"
+        "model": "tusb:item/tool/accessory/magic_square_crystal",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/tool/accessory/magic_square_crystal_v2.json
+++ b/assets/tusb/items/item/tool/accessory/magic_square_crystal_v2.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/tool/accessory/magic_square_crystal_v2"
+        "model": "tusb:item/tool/accessory/magic_square_crystal_v2",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/tool/accessory/warning.json
+++ b/assets/tusb/items/item/tool/accessory/warning.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/tool/accessory/warning"
+        "model": "tusb:item/tool/accessory/warning",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/tool/key/key_block.json
+++ b/assets/tusb/items/item/tool/key/key_block.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/tool/key/key_block"
+        "model": "tusb:item/tool/key/key_block",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/items/item/tool/key/key_block_key.json
+++ b/assets/tusb/items/item/tool/key/key_block_key.json
@@ -1,6 +1,13 @@
 {
     "model": {
         "type": "minecraft:model",
-        "model": "tusb:item/tool/key/key_block_key"
+        "model": "tusb:item/tool/key/key_block_key",
+        "tints": [
+            {
+                "type": "minecraft:custom_model_data",
+                "default": [1.0,1.0,1.0],
+                "index": 0
+            }
+        ]
     }
 }

--- a/assets/tusb/models/item/bullet/common_bomb_1.json
+++ b/assets/tusb/models/item/bullet/common_bomb_1.json
@@ -26,12 +26,12 @@
 			"to": [11, 16, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [10.5, 16.5, 10.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [16, 10, 10],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [10, 10, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [12, 15, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [11, 14.975, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [14.975, 12, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [12, 11, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [11, 12, 14.975],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [15, 11, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [14, 12, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [12, 13, 13.975],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [13, 12, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -208,12 +208,12 @@
 			"to": [13.975, 13, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -222,12 +222,12 @@
 			"to": [13, 14, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -236,12 +236,12 @@
 			"to": [12, 13.975, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -250,12 +250,12 @@
 			"to": [13, 12.975, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -264,12 +264,12 @@
 			"to": [13.994, 9.998, 13.994],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -278,12 +278,12 @@
 			"to": [13.994, 13.994, 9.998],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -292,12 +292,12 @@
 			"to": [9.998, 13.994, 13.994],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -306,12 +306,12 @@
 			"to": [8, 28.908, 14.04454],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -320,12 +320,12 @@
 			"to": [14.04454, 28.908, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -334,12 +334,12 @@
 			"to": [14.66609, 21.12504, 13.5968],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -348,12 +348,12 @@
 			"to": [9.05151, 21.12504, 13.5968],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -362,12 +362,12 @@
 			"to": [13.5968, 21.12504, 9.05151],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -376,12 +376,12 @@
 			"to": [13.5968, 21.12504, 14.66609],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -390,12 +390,12 @@
 			"to": [9.001, 22.022, 9.001],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 22.00518, 8]},
 			"faces": {
-				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/common_bomb_1_huge.json
+++ b/assets/tusb/models/item/bullet/common_bomb_1_huge.json
@@ -26,12 +26,12 @@
 			"to": [11, 16, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [10.5, 16.5, 10.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [16, 10, 10],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [10, 10, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [12, 15, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [11, 14.975, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [14.975, 12, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [12, 11, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [11, 12, 14.975],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [15, 11, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [14, 12, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [12, 13, 13.975],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [13, 12, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -208,12 +208,12 @@
 			"to": [13.975, 13, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -222,12 +222,12 @@
 			"to": [13, 14, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -236,12 +236,12 @@
 			"to": [12, 13.975, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -250,12 +250,12 @@
 			"to": [13, 12.975, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -264,12 +264,12 @@
 			"to": [13.994, 9.998, 13.994],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -278,12 +278,12 @@
 			"to": [13.994, 13.994, 9.998],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -292,12 +292,12 @@
 			"to": [9.998, 13.994, 13.994],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -306,12 +306,12 @@
 			"to": [8, 28.908, 14.04454],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -320,12 +320,12 @@
 			"to": [14.04454, 28.908, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -334,12 +334,12 @@
 			"to": [14.66609, 21.12504, 13.5968],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -348,12 +348,12 @@
 			"to": [9.05151, 21.12504, 13.5968],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -362,12 +362,12 @@
 			"to": [13.5968, 21.12504, 9.05151],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -376,12 +376,12 @@
 			"to": [13.5968, 21.12504, 14.66609],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 23.5627, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -390,12 +390,12 @@
 			"to": [9.001, 22.022, 9.001],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 22.00518, 8]},
 			"faces": {
-				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/common_bomb_2.json
+++ b/assets/tusb/models/item/bullet/common_bomb_2.json
@@ -26,12 +26,12 @@
 			"to": [11.18, 16.48, 11.18],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [10.65, 17.01, 10.65],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [16.48, 10.12, 10.12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [10.12, 10.12, 16.48],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [12.24, 15.42, 11.18],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [11.18, 15.3935, 12.24],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [15.3935, 12.24, 11.18],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [12.24, 11.18, 15.42],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [11.18, 12.24, 15.3935],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [15.42, 11.18, 12.24],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [14.36, 12.24, 13.3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [12.24, 13.3, 14.3335],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [13.3, 12.24, 14.36],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -208,12 +208,12 @@
 			"to": [14.3335, 13.3, 12.24],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -222,12 +222,12 @@
 			"to": [13.3, 14.36, 12.24],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -236,12 +236,12 @@
 			"to": [12.24, 14.3335, 13.3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -250,12 +250,12 @@
 			"to": [13.3, 13.2735, 13.3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -264,12 +264,12 @@
 			"to": [14.35364, 10.11788, 14.35364],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -278,12 +278,12 @@
 			"to": [14.35364, 14.35364, 10.11788],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -292,12 +292,12 @@
 			"to": [10.11788, 14.35364, 14.35364],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -306,12 +306,12 @@
 			"to": [8, 30.15293, 14.28874],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -320,12 +320,12 @@
 			"to": [14.28874, 30.15293, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -334,12 +334,12 @@
 			"to": [16.10641, 21.82261, 13.82291],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -348,12 +348,12 @@
 			"to": [7.92298, 21.82261, 13.82291],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -362,12 +362,12 @@
 			"to": [13.82291, 21.82261, 7.92298],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -376,12 +376,12 @@
 			"to": [13.82291, 21.82261, 16.10641],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -390,12 +390,12 @@
 			"to": [9.001, 22.647, 9.001],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 22.63018, 8]},
 			"faces": {
-				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/common_bomb_2_huge.json
+++ b/assets/tusb/models/item/bullet/common_bomb_2_huge.json
@@ -26,12 +26,12 @@
 			"to": [11.18, 16.48, 11.18],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [10.65, 17.01, 10.65],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [16.48, 10.12, 10.12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [10.12, 10.12, 16.48],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [12.24, 15.42, 11.18],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [11.18, 15.3935, 12.24],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [15.3935, 12.24, 11.18],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [12.24, 11.18, 15.42],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [11.18, 12.24, 15.3935],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [15.42, 11.18, 12.24],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [14.36, 12.24, 13.3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [12.24, 13.3, 14.3335],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [13.3, 12.24, 14.36],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -208,12 +208,12 @@
 			"to": [14.3335, 13.3, 12.24],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -222,12 +222,12 @@
 			"to": [13.3, 14.36, 12.24],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -236,12 +236,12 @@
 			"to": [12.24, 14.3335, 13.3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -250,12 +250,12 @@
 			"to": [13.3, 13.2735, 13.3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -264,12 +264,12 @@
 			"to": [14.35364, 10.11788, 14.35364],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -278,12 +278,12 @@
 			"to": [14.35364, 14.35364, 10.11788],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -292,12 +292,12 @@
 			"to": [10.11788, 14.35364, 14.35364],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -306,12 +306,12 @@
 			"to": [8, 30.15293, 14.28874],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -320,12 +320,12 @@
 			"to": [14.28874, 30.15293, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -334,12 +334,12 @@
 			"to": [16.10641, 21.82261, 13.82291],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -348,12 +348,12 @@
 			"to": [7.92298, 21.82261, 13.82291],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -362,12 +362,12 @@
 			"to": [13.82291, 21.82261, 7.92298],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -376,12 +376,12 @@
 			"to": [13.82291, 21.82261, 16.10641],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 21.53168, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -390,12 +390,12 @@
 			"to": [9.001, 22.647, 9.001],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 22.63018, 8]},
 			"faces": {
-				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/common_bomb_3.json
+++ b/assets/tusb/models/item/bullet/common_bomb_3.json
@@ -26,12 +26,12 @@
 			"to": [11.498, 17.328, 11.498],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [10.915, 17.911, 10.915],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [17.328, 10.332, 10.332],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [10.332, 10.332, 17.328],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [12.664, 16.162, 11.498],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [11.498, 16.13285, 12.664],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [16.13285, 12.664, 11.498],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [12.664, 11.498, 16.162],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [11.498, 12.664, 16.13285],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [16.162, 11.498, 12.664],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [14.996, 12.664, 13.83],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [12.664, 13.83, 14.96685],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [13.83, 12.664, 14.996],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -208,12 +208,12 @@
 			"to": [14.96685, 13.83, 12.664],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -222,12 +222,12 @@
 			"to": [13.83, 14.996, 12.664],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -236,12 +236,12 @@
 			"to": [12.664, 14.96685, 13.83],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -250,12 +250,12 @@
 			"to": [13.83, 13.80085, 13.83],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -264,12 +264,12 @@
 			"to": [14.989, 10.32967, 14.989],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -278,12 +278,12 @@
 			"to": [14.989, 14.989, 10.32967],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -292,12 +292,12 @@
 			"to": [10.32967, 14.989, 14.989],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -306,12 +306,12 @@
 			"to": [8, 30.89913, 14.41205],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -320,12 +320,12 @@
 			"to": [14.41205, 30.89913, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -334,12 +334,12 @@
 			"to": [16.28924, 22.40072, 13.93709],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -348,12 +348,12 @@
 			"to": [7.89759, 22.40072, 13.93709],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -362,12 +362,12 @@
 			"to": [13.93709, 22.40072, 7.89759],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -376,12 +376,12 @@
 			"to": [13.93709, 22.40072, 16.28924],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -390,12 +390,12 @@
 			"to": [9.001, 23.172, 9.001],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 21.7127, 8]},
 			"faces": {
-				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/common_bomb_3_huge.json
+++ b/assets/tusb/models/item/bullet/common_bomb_3_huge.json
@@ -26,12 +26,12 @@
 			"to": [11.498, 17.328, 11.498],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [10.915, 17.911, 10.915],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [17.328, 10.332, 10.332],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [10.332, 10.332, 17.328],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [12.664, 16.162, 11.498],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [11.498, 16.13285, 12.664],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [16.13285, 12.664, 11.498],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [12.664, 11.498, 16.162],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [11.498, 12.664, 16.13285],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [16.162, 11.498, 12.664],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [14.996, 12.664, 13.83],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [12.664, 13.83, 14.96685],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [13.83, 12.664, 14.996],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -208,12 +208,12 @@
 			"to": [14.96685, 13.83, 12.664],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -222,12 +222,12 @@
 			"to": [13.83, 14.996, 12.664],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -236,12 +236,12 @@
 			"to": [12.664, 14.96685, 13.83],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -250,12 +250,12 @@
 			"to": [13.83, 13.80085, 13.83],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -264,12 +264,12 @@
 			"to": [14.989, 10.32967, 14.989],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -278,12 +278,12 @@
 			"to": [14.989, 14.989, 10.32967],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -292,12 +292,12 @@
 			"to": [10.32967, 14.989, 14.989],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -306,12 +306,12 @@
 			"to": [8, 30.89913, 14.41205],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -320,12 +320,12 @@
 			"to": [14.41205, 30.89913, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -334,12 +334,12 @@
 			"to": [16.28924, 22.40072, 13.93709],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -348,12 +348,12 @@
 			"to": [7.89759, 22.40072, 13.93709],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -362,12 +362,12 @@
 			"to": [13.93709, 22.40072, 7.89759],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -376,12 +376,12 @@
 			"to": [13.93709, 22.40072, 16.28924],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 22.04643, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -390,12 +390,12 @@
 			"to": [9.001, 23.172, 9.001],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 21.7127, 8]},
 			"faces": {
-				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/common_bomb_4.json
+++ b/assets/tusb/models/item/bullet/common_bomb_4.json
@@ -26,12 +26,12 @@
 			"to": [11.98772, 18.63392, 11.98772],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [11.3231, 19.29854, 11.3231],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [18.63392, 10.65848, 10.65848],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [10.65848, 10.65848, 18.63392],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [13.31696, 17.30468, 11.98772],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [11.98772, 17.27145, 13.31696],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [17.27145, 13.31696, 11.98772],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [13.31696, 11.98772, 17.30468],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [11.98772, 13.31696, 17.27145],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [17.30468, 11.98772, 13.31696],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [15.97544, 13.31696, 14.6462],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [13.31696, 14.6462, 15.94221],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [14.6462, 13.31696, 15.97544],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -208,12 +208,12 @@
 			"to": [15.94221, 14.6462, 13.31696],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -222,12 +222,12 @@
 			"to": [14.6462, 15.97544, 13.31696],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -236,12 +236,12 @@
 			"to": [13.31696, 15.94221, 14.6462],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -250,12 +250,12 @@
 			"to": [14.6462, 14.61297, 14.6462],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -264,12 +264,12 @@
 			"to": [15.96746, 10.65582, 15.96746],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -278,12 +278,12 @@
 			"to": [15.96746, 15.96746, 10.65582],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -292,12 +292,12 @@
 			"to": [10.65582, 15.96746, 15.96746],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -306,12 +306,12 @@
 			"to": [8, 32, 14.5281],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -320,12 +320,12 @@
 			"to": [14.5281, 32, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -334,12 +334,12 @@
 			"to": [16.43927, 23.46741, 14.04454],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -348,12 +348,12 @@
 			"to": [7.89574, 23.46741, 14.04454],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -362,12 +362,12 @@
 			"to": [14.04454, 23.46741, 7.89574],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -376,12 +376,12 @@
 			"to": [14.04454, 23.46741, 16.43927],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -390,12 +390,12 @@
 			"to": [9.001, 23.447, 9.001],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 23.43018, 8]},
 			"faces": {
-				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/common_bomb_4_huge.json
+++ b/assets/tusb/models/item/bullet/common_bomb_4_huge.json
@@ -26,12 +26,12 @@
 			"to": [11.98772, 18.63392, 11.98772],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 8, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10.5, 5.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [11.3231, 19.29854, 11.3231],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.75, 8, 5.25, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [18.63392, 10.65848, 10.65848],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 11, 8, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [10.65848, 10.65848, 18.63392],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 3, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 8, 5, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [13.31696, 17.30468, 11.98772],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 10.5, 6, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [11.98772, 17.27145, 13.31696],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 1, 5.5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1, 6, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 10, 5.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [17.27145, 13.31696, 11.98772],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 10.5, 7.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7.5, 13.5, 0.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [13.31696, 11.98772, 17.30468],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [11.98772, 13.31696, 17.27145],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 2, 5.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 2, 7.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 8.5, 5.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 8.5, 5.5, 15.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [17.30468, 11.98772, 13.31696],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 2.5, 7.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 2.5, 6, 5.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [15.97544, 13.31696, 14.6462],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 10, 7, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [13.31696, 14.6462, 15.94221],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 14, 7, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 10, 7, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [14.6462, 13.31696, 15.97544],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2, 6.5, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 2, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 9, 2, 15], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -208,12 +208,12 @@
 			"to": [15.94221, 14.6462, 13.31696],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1.5, 7, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 1.5, 6, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 15, 6, 9], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9, 6, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -222,12 +222,12 @@
 			"to": [14.6462, 15.97544, 13.31696],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -236,12 +236,12 @@
 			"to": [13.31696, 15.94221, 14.6462],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 10, 6.5, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -250,12 +250,12 @@
 			"to": [14.6462, 14.61297, 14.6462],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 9.5, 6.5, 14.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -264,12 +264,12 @@
 			"to": [15.96746, 10.65582, 15.96746],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 3, 7, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -278,12 +278,12 @@
 			"to": [15.96746, 15.96746, 10.65582],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -292,12 +292,12 @@
 			"to": [10.65582, 15.96746, 15.96746],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 1, 5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 11, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -306,12 +306,12 @@
 			"to": [8, 32, 14.5281],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -320,12 +320,12 @@
 			"to": [14.5281, 32, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 7.5, 9, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -334,12 +334,12 @@
 			"to": [16.43927, 23.46741, 14.04454],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 8, 9, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -348,12 +348,12 @@
 			"to": [7.89574, 23.46741, 14.04454],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -362,12 +362,12 @@
 			"to": [14.04454, 23.46741, 7.89574],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -376,12 +376,12 @@
 			"to": [14.04454, 23.46741, 16.43927],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 23.10672, 8]},
 			"faces": {
-				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 8.5, 7.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 8.5, 7.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -390,12 +390,12 @@
 			"to": [9.001, 23.447, 9.001],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 23.43018, 8]},
 			"faces": {
-				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 10, 2], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 6, 10, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/etc/bone_bullet.json
+++ b/assets/tusb/models/item/bullet/etc/bone_bullet.json
@@ -1,7 +1,6 @@
 {
     "parent": "item/generated",
     "textures": {
-        "layer0": "tusb:item/common/clear_dots",
-        "layer1": "tusb:item/bullet/overlay/etc/bone_bullet"
+        "layer0": "tusb:item/bullet/overlay/etc/bone_bullet"
     }
 }

--- a/assets/tusb/models/item/bullet/etc/cannon_ball.json
+++ b/assets/tusb/models/item/bullet/etc/cannon_ball.json
@@ -1,7 +1,6 @@
 {
     "parent": "item/generated",
     "textures": {
-        "layer0": "tusb:item/common/clear_dots",
-        "layer1": "tusb:item/bullet/overlay/etc/cannon_ball"
+        "layer0": "tusb:item/bullet/overlay/etc/cannon_ball"
     }
 }

--- a/assets/tusb/models/item/bullet/etc/color_egg.json
+++ b/assets/tusb/models/item/bullet/etc/color_egg.json
@@ -1,7 +1,6 @@
 {
     "parent": "item/generated",
     "textures": {
-        "layer0": "tusb:item/common/clear_dots",
-        "layer1": "tusb:item/bullet/overlay/etc/color_egg"
+        "layer0": "tusb:item/bullet/overlay/etc/color_egg"
     }
 }

--- a/assets/tusb/models/item/bullet/etc/color_pearl.json
+++ b/assets/tusb/models/item/bullet/etc/color_pearl.json
@@ -1,7 +1,6 @@
 {
     "parent": "item/generated",
     "textures": {
-        "layer0": "tusb:item/common/clear_dots",
-        "layer1": "tusb:item/bullet/overlay/etc/color_pearl"
+        "layer0": "tusb:item/bullet/overlay/etc/color_pearl"
     }
 }

--- a/assets/tusb/models/item/bullet/etc/shuriken.json
+++ b/assets/tusb/models/item/bullet/etc/shuriken.json
@@ -7,7 +7,6 @@
         }
     },
     "textures": {
-        "layer0": "tusb:item/common/clear_dots",
-        "layer1": "tusb:item/bullet/overlay/etc/shuriken"
+        "layer0": "tusb:item/bullet/overlay/etc/shuriken"
     }
 }

--- a/assets/tusb/models/item/bullet/etc/throwing_knife.json
+++ b/assets/tusb/models/item/bullet/etc/throwing_knife.json
@@ -32,7 +32,6 @@
         }
     },
     "textures": {
-        "layer0": "tusb:item/common/clear_dots",
-        "layer1": "tusb:item/bullet/overlay/etc/throwing_knife"
+        "layer0": "tusb:item/bullet/overlay/etc/throwing_knife"
     }
 }

--- a/assets/tusb/models/item/bullet/kana_tarai.json
+++ b/assets/tusb/models/item/bullet/kana_tarai.json
@@ -12,12 +12,12 @@
 			"to": [16, 1, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -26,12 +26,12 @@
 			"to": [16, 6, 0],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [17, 6, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [16, 6, 17],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 1], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 1], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 1], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 1], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [0, 6, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 1], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 1], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 1], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 1], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [0, 7, 17],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 1, 1], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 1, 1], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 1, 1], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 1, 1], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [16, 7, -1],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [18, 7, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 1], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 1], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 1], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 1], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [16, 7, 18],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 1], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 1], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 1], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 1], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [-1, 7, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 1], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 1], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 1], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 1], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [0, 7, 0],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [17, 7, 0],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 1, 1], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 1, 1], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 1, 1], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 1, 1], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [17, 7, 17],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 1, 1], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 1, 1], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 1, 1], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 1, 1], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/laser_shot.json
+++ b/assets/tusb/models/item/bullet/laser_shot.json
@@ -11,12 +11,12 @@
 			"to": [14.8, 14.8, -3.8],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -25,12 +25,12 @@
 			"to": [14.8, 8, -3.8],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 0, 8, 8], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 8], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 0, 8, 8], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 8], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -39,12 +39,12 @@
 			"to": [8, 8, -3.8],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 0, 8, 8], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 8], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 0, 8, 8], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 8], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -53,12 +53,12 @@
 			"to": [8, 14.8, -3.8],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 0, 8, 8], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 8], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 0, 8, 8], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 8], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -67,12 +67,12 @@
 			"to": [14.8, 8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 0, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 16, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 0, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 16, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -81,12 +81,12 @@
 			"to": [14.8, 14.8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 8, 0, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 8, 0, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -95,12 +95,12 @@
 			"to": [14.8, 14.8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 0, 8], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 16, 16, 8], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 0, 8], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 16, 16, 8], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -109,12 +109,12 @@
 			"to": [8, 14.8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 0, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 8, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 0, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 8, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -123,12 +123,12 @@
 			"to": [1.2, 8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 8, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 8, 0, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 8, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 8, 0, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -137,12 +137,12 @@
 			"to": [1.2, 14.8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 16, 16, 8], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 0, 8], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 16, 16, 8], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 0, 8], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -151,12 +151,12 @@
 			"to": [14.8, 1.2, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 8, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 8, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -165,12 +165,12 @@
 			"to": [8, 1.2, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 16, 16, 8], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 0, 8], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 16, 16, 8], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 0, 8], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -179,12 +179,12 @@
 			"to": [11, 11, 20],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 9]},
 			"faces": {
-				"north": {"uv": [16, 16, 15.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 15.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -193,12 +193,12 @@
 			"to": [11, 11, 8],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 15.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 15.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -207,12 +207,12 @@
 			"to": [11, 11, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 10]},
 			"faces": {
-				"north": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{

--- a/assets/tusb/models/item/bullet/laser_shot_huge.json
+++ b/assets/tusb/models/item/bullet/laser_shot_huge.json
@@ -11,12 +11,12 @@
 			"to": [14.8, 14.8, -3.8],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -25,12 +25,12 @@
 			"to": [14.8, 8, -3.8],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 0, 8, 8], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 8], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 0, 8, 8], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 8], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -39,12 +39,12 @@
 			"to": [8, 8, -3.8],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 0, 8, 8], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 8], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 0, 8, 8], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 8], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -53,12 +53,12 @@
 			"to": [8, 14.8, -3.8],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 0, 8, 8], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 8], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 0, 8, 8], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 8], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -67,12 +67,12 @@
 			"to": [14.8, 8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 0, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 16, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 0, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 16, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -81,12 +81,12 @@
 			"to": [14.8, 14.8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 8, 0, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 8, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 8, 0, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 8, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -95,12 +95,12 @@
 			"to": [14.8, 14.8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 0, 8], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 16, 16, 8], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 0, 8], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 16, 16, 8], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -109,12 +109,12 @@
 			"to": [8, 14.8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 0, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 8, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 0, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 8, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -123,12 +123,12 @@
 			"to": [1.2, 8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 8, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 8, 0, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 8, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 8, 0, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -137,12 +137,12 @@
 			"to": [1.2, 14.8, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 16, 16, 8], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 0, 8], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 16, 16, 8], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 0, 8], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -151,12 +151,12 @@
 			"to": [14.8, 1.2, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 8, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 8, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 8, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 8, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -165,12 +165,12 @@
 			"to": [8, 1.2, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7.36]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 16, 16, 8], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 0, 8], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 16, 16, 8], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 0, 8], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -179,12 +179,12 @@
 			"to": [11, 11, 20],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 9]},
 			"faces": {
-				"north": {"uv": [16, 16, 15.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 15.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -193,12 +193,12 @@
 			"to": [11, 11, 8],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 7]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 15.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 15.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -207,12 +207,12 @@
 			"to": [11, 11, 32],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 10]},
 			"faces": {
-				"north": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{

--- a/assets/tusb/models/item/bullet/magnum.json
+++ b/assets/tusb/models/item/bullet/magnum.json
@@ -53,12 +53,12 @@
 			"to": [12, 12, 15.75],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 14.25]},
 			"faces": {
-				"north": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -67,12 +67,12 @@
 			"to": [9.5, 9.5, 6.75],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 2.75]},
 			"faces": {
-				"north": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 10, 8.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -81,12 +81,12 @@
 			"to": [13.25, 13.25, 14.75],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 13.75]},
 			"faces": {
-				"north": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 12, 8.5, 12.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -95,12 +95,12 @@
 			"to": [13.25, 13.25, 11.75],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 13.75]},
 			"faces": {
-				"north": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 11.5, 8.5, 12], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -109,12 +109,12 @@
 			"to": [12.25, 12.25, 7.75],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 13.75]},
 			"faces": {
-				"north": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 8, 8.5, 8.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -123,12 +123,12 @@
 			"to": [10, 10, 32],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 14.25]},
 			"faces": {
-				"north": {"uv": [15.5, 8, 16, 8.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 8, 15, 8.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [15.5, 8, 16, 8.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 8, 15, 8.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 8, 15, 8.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 8, 15, 8.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [15.5, 8, 16, 8.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 8, 15, 8.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [15.5, 8, 16, 8.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 8, 15, 8.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 8, 15, 8.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 8, 15, 8.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -137,12 +137,12 @@
 			"to": [4, 12, 26.75],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 20.375]},
 			"faces": {
-				"north": {"uv": [15.5, 9, 16, 9.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12, 10, 16, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [15.5, 9, 16, 9.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 10, 15.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12, 10, 16, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12, 10, 16, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [15.5, 9, 16, 9.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12, 10, 16, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [15.5, 9, 16, 9.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 10, 15.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12, 10, 16, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12, 10, 16, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -151,12 +151,12 @@
 			"to": [12, 12, 26.75],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 20.375]},
 			"faces": {
-				"north": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 10, 15.5, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12, 10, 16, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12, 10, 16, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12, 10, 16, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 10, 15.5, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12, 10, 16, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12, 10, 16, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12, 10, 16, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -165,12 +165,12 @@
 			"to": [12, 4, 26.75],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 20.375]},
 			"faces": {
-				"north": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12, 10, 16, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12, 10, 16, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12, 10, 16, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 10, 15.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12, 10, 16, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12, 10, 16, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12, 10, 16, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 10, 15.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -179,12 +179,12 @@
 			"to": [12, 12, 26.75],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 20.375]},
 			"faces": {
-				"north": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12, 10, 16, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12, 10, 16, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 10, 15.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12, 10, 16, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12, 10, 16, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [15.5, 10, 16, 10.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12, 10, 16, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 10, 15.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12, 10, 16, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/sonic_boom.json
+++ b/assets/tusb/models/item/bullet/sonic_boom.json
@@ -1,7 +1,6 @@
 {
     "parent": "item/generated",
     "textures": {
-        "layer0": "tusb:item/common/clear_dots",
-        "layer1": "tusb:item/bullet/sonic_boom"
+        "layer0": "tusb:item/bullet/sonic_boom"
     }
 }

--- a/assets/tusb/models/item/bullet/stone_bullet.json
+++ b/assets/tusb/models/item/bullet/stone_bullet.json
@@ -11,12 +11,12 @@
 			"to": [13.6661, 12.8076, 13.6661],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -25,12 +25,12 @@
 			"to": [13.11666, 13.11666, 13.11666],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -39,12 +39,12 @@
 			"to": [12.8076, 13.6661, 13.6661],
 			"rotation": {"angle": -45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -53,12 +53,12 @@
 			"to": [13.6661, 13.6661, 12.8076],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -67,12 +67,12 @@
 			"to": [14.6963, 12.6359, 12.6359],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 14, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 14, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 14, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 14, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -81,12 +81,12 @@
 			"to": [12.6359, 14.6963, 12.6359],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 14, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 14, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -95,12 +95,12 @@
 			"to": [12.6359, 12.6359, 14.6963],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 14, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 14, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 14, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 14, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 14, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 14, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/thorn_iron_ball.json
+++ b/assets/tusb/models/item/bullet/thorn_iron_ball.json
@@ -12,12 +12,12 @@
 			"to": [12.5, 19, 12.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -26,12 +26,12 @@
 			"to": [11.5, 20, 11.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [10.5, 23, 10.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [9.5, 26, 9.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [8.5, 31, 8.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [19, 12.5, 12.5],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 6, 5, 10], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 6, 5, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 6, 5, 10], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 6, 5, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [20, 11.5, 11.5],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [23, 10.5, 10.5],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 4, 4, 12], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 4, 4, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 4, 4, 12], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 4, 4, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [26, 9.5, 9.5],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [31, 8.5, 8.5],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 0, 3, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 0, 3, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 0, 3, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 0, 3, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [12.5, 12.5, 19],
 			"rotation": {"angle": 0, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [11, 0, 16, 5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5, 6, 10, 10], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 6, 5, 10], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11, 0, 16, 5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5, 6, 10, 10], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 6, 5, 10], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [11.5, 11.5, 20],
 			"rotation": {"angle": 0, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [10.5, 10.5, 23],
 			"rotation": {"angle": 0, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [12, 1, 15, 4], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 4, 9, 12], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 4, 4, 12], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [12, 1, 15, 4], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 4, 9, 12], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 4, 4, 12], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [9.5, 9.5, 26],
 			"rotation": {"angle": 0, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -208,12 +208,12 @@
 			"to": [8.5, 8.5, 31],
 			"rotation": {"angle": 0, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [13, 2, 14, 3], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7, 0, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 0, 3, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [13, 2, 14, 3], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7, 0, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 0, 3, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -222,12 +222,12 @@
 			"to": [12.5, 19, 12.5],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -236,12 +236,12 @@
 			"to": [11.5, 20, 11.5],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -250,12 +250,12 @@
 			"to": [10.5, 23, 10.5],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -264,12 +264,12 @@
 			"to": [9.5, 26, 9.5],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -278,12 +278,12 @@
 			"to": [8.5, 31, 8.5],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -292,12 +292,12 @@
 			"to": [12.5, 12.5, 19],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [11, 0, 16, 5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5, 6, 10, 10], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 6, 5, 10], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11, 0, 16, 5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5, 6, 10, 10], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 6, 5, 10], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -306,12 +306,12 @@
 			"to": [11.5, 11.5, 20],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -320,12 +320,12 @@
 			"to": [10.5, 10.5, 23],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [12, 1, 15, 4], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 4, 9, 12], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 4, 4, 12], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [12, 1, 15, 4], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 4, 9, 12], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 4, 4, 12], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -334,12 +334,12 @@
 			"to": [9.5, 9.5, 26],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -348,12 +348,12 @@
 			"to": [8.5, 8.5, 31],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [13, 2, 14, 3], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7, 0, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 0, 3, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [13, 2, 14, 3], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7, 0, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 0, 3, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -362,12 +362,12 @@
 			"to": [12.5, 19, 12.5],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 6, 5, 10], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5, 6, 10, 10], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [11, 0, 16, 5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -376,12 +376,12 @@
 			"to": [11.5, 20, 11.5],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5.5, 5.5, 9.5, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [11.5, 0.5, 15.5, 4.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -390,12 +390,12 @@
 			"to": [10.5, 23, 10.5],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 4, 4, 12], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 4, 9, 12], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12, 1, 15, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -404,12 +404,12 @@
 			"to": [9.5, 26, 9.5],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6.5, 2.5, 8.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12.5, 1.5, 14.5, 3.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -418,12 +418,12 @@
 			"to": [8.5, 31, 8.5],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 0, 3, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [13, 2, 14, 3], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -432,12 +432,12 @@
 			"to": [19, 12.5, 12.5],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 6, 5, 10], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 6, 5, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 6, 5, 10], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 6, 5, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -446,12 +446,12 @@
 			"to": [20, 11.5, 11.5],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -460,12 +460,12 @@
 			"to": [23, 10.5, 10.5],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 4, 4, 12], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 4, 4, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 4, 4, 12], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 4, 4, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -474,12 +474,12 @@
 			"to": [26, 9.5, 9.5],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -488,12 +488,12 @@
 			"to": [31, 8.5, 8.5],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 0, 3, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 0, 3, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 0, 3, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 0, 3, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -502,12 +502,12 @@
 			"to": [19, 12.5, 12.5],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 6, 5, 10], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 6, 5, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 6, 5, 10], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 6, 5, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -516,12 +516,12 @@
 			"to": [20, 11.5, 11.5],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -530,12 +530,12 @@
 			"to": [23, 10.5, 10.5],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 4, 4, 12], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 4, 4, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 4, 4, 12], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 4, 4, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -544,12 +544,12 @@
 			"to": [26, 9.5, 9.5],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -558,12 +558,12 @@
 			"to": [31, 8.5, 8.5],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 0, 3, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 0, 3, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 0, 3, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 0, 3, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -572,12 +572,12 @@
 			"to": [19, 12.5, 12.5],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 6, 5, 10], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 6, 5, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 6, 5, 10], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 6, 5, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [11, 0, 16, 5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5, 6, 10, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -586,12 +586,12 @@
 			"to": [20, 11.5, 11.5],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 5.5, 4.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [11.5, 0.5, 15.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.5, 5.5, 9.5, 10.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -600,12 +600,12 @@
 			"to": [23, 10.5, 10.5],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1, 4, 4, 12], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 4, 4, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 4, 4, 12], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 4, 4, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12, 1, 15, 4], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6, 4, 9, 12], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -614,12 +614,12 @@
 			"to": [26, 9.5, 9.5],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 2.5, 3.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12.5, 1.5, 14.5, 3.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6.5, 2.5, 8.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -628,12 +628,12 @@
 			"to": [31, 8.5, 8.5],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [2, 0, 3, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 0, 3, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 0, 3, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 0, 3, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [13, 2, 14, 3], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7, 0, 8, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/bullet/white_dots.json
+++ b/assets/tusb/models/item/bullet/white_dots.json
@@ -9,12 +9,12 @@
 			"from": [0, 0, 0],
 			"to": [16, 16, 16],
 			"faces": {
-				"north": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [14, 0, 15, 1], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/angel_ring.json
+++ b/assets/tusb/models/item/mob/angel_ring.json
@@ -10,12 +10,12 @@
 			"to": [8.3, 8.3, 5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [8, 1, 0, 0], "rotation": 270, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 1], "rotation": 90, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [8, 1, 0, 0], "rotation": 270, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 1], "rotation": 90, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -23,12 +23,12 @@
 			"to": [8.3, 8.3, 5],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -36,12 +36,12 @@
 			"to": [5, 8.3, 8.3],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 1},
-				"west": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 0},
+				"west": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -49,12 +49,12 @@
 			"to": [8.3, 8.3, 5],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -62,12 +62,12 @@
 			"to": [5, 8.3, 8.3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [8, 1, 0, 0], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [7, 1, 8, 0], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 8, 0], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 1, 0], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 8, 0], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [8, 1, 0, 0], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [7, 1, 8, 0], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 8, 0], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 1, 0], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 8, 0], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -75,12 +75,12 @@
 			"to": [5, 8.3, 8.3],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [6, 2, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [5, 2, 6, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [6, 2, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [5, 2, 6, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -88,12 +88,12 @@
 			"to": [8.3, 8.3, 14],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 2, 6, 1], "rotation": 180, "texture": "#0", "tintindex": 1},
-				"south": {"uv": [6, 2, 5, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 2, 6, 1], "rotation": 90, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 2, 6, 1], "rotation": 270, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 2, 6, 1], "rotation": 180, "texture": "#0", "tintindex": 0},
+				"south": {"uv": [6, 2, 5, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 2, 6, 1], "rotation": 90, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 2, 6, 1], "rotation": 270, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -101,12 +101,12 @@
 			"to": [5, 8.3, 8.3],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [6, 2, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [5, 2, 6, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [6, 2, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [5, 2, 6, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -114,12 +114,12 @@
 			"to": [8.3, 8.3, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [8, 1, 0, 0], "rotation": 90, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 1], "rotation": 270, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [8, 1, 0, 0], "rotation": 90, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 1], "rotation": 270, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -127,12 +127,12 @@
 			"to": [8.3, 8.3, 14],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -140,12 +140,12 @@
 			"to": [14, 8.3, 8.3],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 1},
-				"east": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 0},
+				"east": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -153,12 +153,12 @@
 			"to": [8.3, 8.3, 14],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [16, 8.3, 8.3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [8, 1, 0, 0], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [8, 1, 0, 0], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -179,12 +179,12 @@
 			"to": [14, 8.3, 8.3],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -192,12 +192,12 @@
 			"to": [8.3, 8.3, 5],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -205,12 +205,12 @@
 			"to": [14, 8.3, 8.3],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0}
 			}
 		}
 	]

--- a/assets/tusb/models/item/mob/angel_ring3.json
+++ b/assets/tusb/models/item/mob/angel_ring3.json
@@ -10,12 +10,12 @@
 			"to": [8.3, 8.3, -1],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [8, 1, 0, 0], "rotation": 270, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 1], "rotation": 90, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [8, 1, 0, 0], "rotation": 270, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 1], "rotation": 90, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -23,12 +23,12 @@
 			"to": [8.3, 8.3, -1],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -36,12 +36,12 @@
 			"to": [-1, 8.3, 8.3],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 1},
-				"west": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 0},
+				"west": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -49,12 +49,12 @@
 			"to": [8.3, 8.3, -1],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -62,12 +62,12 @@
 			"to": [-1, 8.3, 8.3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [8, 1, 0, 0], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [7, 1, 8, 0], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 8, 0], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 1, 0], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 8, 0], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [8, 1, 0, 0], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [7, 1, 8, 0], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 8, 0], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 1, 0], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 8, 0], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -75,12 +75,12 @@
 			"to": [-1, 8.3, 8.3],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [6, 2, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [5, 2, 6, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [6, 2, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [5, 2, 6, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -88,12 +88,12 @@
 			"to": [8.3, 8.3, 20],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 2, 6, 1], "rotation": 180, "texture": "#0", "tintindex": 1},
-				"south": {"uv": [6, 2, 5, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 2, 6, 1], "rotation": 90, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 2, 6, 1], "rotation": 270, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 2, 6, 1], "rotation": 180, "texture": "#0", "tintindex": 0},
+				"south": {"uv": [6, 2, 5, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 2, 6, 1], "rotation": 90, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 2, 6, 1], "rotation": 270, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -101,12 +101,12 @@
 			"to": [-1, 8.3, 8.3],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [6, 2, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [5, 2, 6, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 2, 6, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 2, 1, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [6, 2, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [5, 2, 6, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -114,12 +114,12 @@
 			"to": [8.3, 8.3, 22],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [8, 1, 0, 0], "rotation": 90, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 1], "rotation": 270, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [8, 1, 0, 0], "rotation": 90, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 1], "rotation": 270, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -127,12 +127,12 @@
 			"to": [8.3, 8.3, 20],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -140,12 +140,12 @@
 			"to": [20, 8.3, 8.3],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 1},
-				"east": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 0},
+				"east": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -153,12 +153,12 @@
 			"to": [8.3, 8.3, 20],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [22, 8.3, 8.3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [8, 1, 0, 0], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [7, 0, 8, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [8, 1, 0, 0], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -179,12 +179,12 @@
 			"to": [20, 8.3, 8.3],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -192,12 +192,12 @@
 			"to": [8.3, 8.3, -1],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 1}
+				"north": {"uv": [6, 1, 5, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 6, 2], "rotation": 180, "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "rotation": 270, "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "rotation": 90, "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -205,12 +205,12 @@
 			"to": [20, 8.3, 8.3],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [6, 1, 0, 2], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [5, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 1, 2], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 6, 2], "texture": "#0", "tintindex": 0}
 			}
 		}
 	]

--- a/assets/tusb/models/item/mob/cannon_body.json
+++ b/assets/tusb/models/item/mob/cannon_body.json
@@ -12,12 +12,12 @@
 			"to": [13, 13, 18],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 8, 0.75]},
 			"faces": {
-				"north": {"uv": [0, 16, 0, 16], "texture": "#layer2", "tintindex": 1},
-				"east": {"uv": [12, 3, 13, 13], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 3, 13, 13], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3, 3, 4, 13], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3, 3, 13, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 12, 13, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 16, 0, 16], "texture": "#layer2", "tintindex": 0},
+				"east": {"uv": [12, 3, 13, 13], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 3, 13, 13], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3, 3, 4, 13], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3, 3, 13, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 12, 13, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -26,12 +26,12 @@
 			"to": [15, 15, 17],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 8, 0.75]},
 			"faces": {
-				"north": {"uv": [15, 1, 1, 15], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 1, 14, 15], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 1, 15, 15], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 1, 16, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 0, 15, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15, 16, 1, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [15, 1, 1, 15], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 1, 14, 15], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 1, 15, 15], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 1, 16, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 0, 15, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15, 16, 1, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [16, 16, 16],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 8, 0.75]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [14, 14, -1],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 8, 0.75]},
 			"faces": {
-				"north": {"uv": [14, 2, 2, 14], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12, 2, 15, 14], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 16, 0, 16], "texture": "#layer2", "tintindex": 1},
-				"west": {"uv": [1, 2, 4, 14], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 1, 14, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 12, 14, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 2, 2, 14], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12, 2, 15, 14], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 16, 0, 16], "texture": "#layer2", "tintindex": 0},
+				"west": {"uv": [1, 2, 4, 14], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 1, 14, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 12, 14, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [13, 13, -4],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 8, 0.75]},
 			"faces": {
-				"north": {"uv": [10, 0, 0, 10], "texture": "#layer2", "tintindex": 1},
-				"east": {"uv": [11, 3, 16, 13], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"west": {"uv": [6, 3, 1, 13], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [4, 5, 14, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [14, 10, 4, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [10, 0, 0, 10], "texture": "#layer2", "tintindex": 0},
+				"east": {"uv": [11, 3, 16, 13], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"west": {"uv": [6, 3, 1, 13], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [4, 5, 14, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [14, 10, 4, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/cannon_legs.json
+++ b/assets/tusb/models/item/mob/cannon_legs.json
@@ -11,12 +11,12 @@
 			"to": [0, 13, 13],
 			"rotation": {"angle": -45, "axis": "x", "origin": [-2, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 12, 4, 2], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 13, 13], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11, 2, 7, 12], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [13, 3, 3, 13], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 12, 4, 2], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [14, 12, 10, 2], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 12, 4, 2], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 13, 13], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11, 2, 7, 12], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [13, 3, 3, 13], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 12, 4, 2], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [14, 12, 10, 2], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -25,12 +25,12 @@
 			"to": [1, 11, 11],
 			"rotation": {"angle": -45, "axis": "x", "origin": [-2, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 10, 6, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 10, 0, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [4, 5, 10, 11], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [4, 6, 10, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [4, 0, 10, 6], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15, 11, 9, 5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 10, 6, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 10, 0, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [4, 5, 10, 11], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [4, 6, 10, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [4, 0, 10, 6], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15, 11, 9, 5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -39,12 +39,12 @@
 			"to": [-0.5, 8.3, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-2, 0.3, 8]},
 			"faces": {
-				"north": {"uv": [9, 12, 6, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 12, 8, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [13, 0, 16, 12], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 12, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [11, 2.5, 12.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [11.5, 0.5, 13, 3.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 12, 6, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 12, 8, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [13, 0, 16, 12], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 12, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [11, 2.5, 12.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [11.5, 0.5, 13, 3.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -53,12 +53,12 @@
 			"to": [0, -3.7, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-2, 0.3, 8]},
 			"faces": {
-				"north": {"uv": [4, 6, 9, 4], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14, 4, 4, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 13, 11, 15], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 10, 4, 12], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 4, 4, 14], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12, 14, 7, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [4, 6, 9, 4], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14, 4, 4, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 13, 11, 15], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 10, 4, 12], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 4, 4, 14], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12, 14, 7, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -67,12 +67,12 @@
 			"to": [-0.02513, -3.93934, 12],
 			"rotation": {"angle": -45, "axis": "z", "origin": [-2.5, -4, 7]},
 			"faces": {
-				"north": {"uv": [8, 2, 11, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 4, 10, 7], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 2, 11, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 9, 10, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 6, 10, 9], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10, 6.03553, 2, 3], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 2, 11, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 4, 10, 7], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 2, 11, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 9, 10, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 6, 10, 9], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10, 6.03553, 2, 3], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -81,12 +81,12 @@
 			"to": [-1.001, -0.7, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-2, 0.3, 8]},
 			"faces": {
-				"north": {"uv": [8.498, 4, 6.5, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [10, 4, 13, 12], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [12.5, 4, 10.502, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7, 13, 4, 5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5, 3, 13, 4.998], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [14, 6.498, 6, 4.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8.498, 4, 6.5, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [10, 4, 13, 12], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [12.5, 4, 10.502, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7, 13, 4, 5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5, 3, 13, 4.998], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [14, 6.498, 6, 4.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -95,12 +95,12 @@
 			"to": [-1, 2.40925, 11.47103],
 			"rotation": {"angle": 45, "axis": "x", "origin": [-2, 0.2161, 7.98232]},
 			"faces": {
-				"north": {"uv": [8.5, 10, 6.5, 4], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [7, 10, 11, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11, 1.5, 12, 4.32843], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 9, 10, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [10.5, 10, 8.5, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [13, 2.5, 14, 5.32843], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8.5, 10, 6.5, 4], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [7, 10, 11, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11, 1.5, 12, 4.32843], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 9, 10, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [10.5, 10, 8.5, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [13, 2.5, 14, 5.32843], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -109,12 +109,12 @@
 			"to": [20, 13, 13],
 			"rotation": {"angle": -45, "axis": "x", "origin": [18, 8, 8]},
 			"faces": {
-				"north": {"uv": [4, 12, 0, 2], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3, 3, 13, 13], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [7, 2, 11, 12], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [13, 3, 3, 13], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [4, 12, 8, 2], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10, 12, 14, 2], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [4, 12, 0, 2], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3, 3, 13, 13], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [7, 2, 11, 12], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [13, 3, 3, 13], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [4, 12, 8, 2], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10, 12, 14, 2], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -123,12 +123,12 @@
 			"to": [21, 11, 11],
 			"rotation": {"angle": -45, "axis": "x", "origin": [18, 8, 8]},
 			"faces": {
-				"north": {"uv": [6, 10, 0, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [4, 0, 10, 6], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [10, 5, 4, 11], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 10, 6, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [10, 0, 4, 6], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 11, 15, 5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 10, 0, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [4, 0, 10, 6], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [10, 5, 4, 11], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 10, 6, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [10, 0, 4, 6], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 11, 15, 5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -137,12 +137,12 @@
 			"to": [19.5, 8.3, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [18, 0.3, 8]},
 			"faces": {
-				"north": {"uv": [6, 12, 9, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 12, 6, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 0, 13, 12], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 12, 14, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12.5, 2.5, 11, 5.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [13, 0.5, 11.5, 3.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 12, 9, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 12, 6, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 0, 13, 12], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 12, 14, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12.5, 2.5, 11, 5.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [13, 0.5, 11.5, 3.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -151,12 +151,12 @@
 			"to": [21, -3.7, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [18, 0.3, 8]},
 			"faces": {
-				"north": {"uv": [9, 6, 4, 4], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [4, 10, 14, 12], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11, 13, 16, 15], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [4, 4, 14, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [4, 4, 9, 14], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7, 14, 12, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 6, 4, 4], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [4, 10, 14, 12], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11, 13, 16, 15], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [4, 4, 14, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [4, 4, 9, 14], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7, 14, 12, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -165,12 +165,12 @@
 			"to": [18.56066, -3.93934, 12],
 			"rotation": {"angle": 45, "axis": "z", "origin": [18.5, -4, 7]},
 			"faces": {
-				"north": {"uv": [11, 2, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [10, 9, 2, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11, 2, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [10, 4, 2, 7], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 9, 10, 6], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10, 3, 2, 6.03553], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11, 2, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [10, 9, 2, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11, 2, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [10, 4, 2, 7], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 9, 10, 6], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10, 3, 2, 6.03553], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -179,12 +179,12 @@
 			"to": [18.999, -0.7, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [18, 0.3, 8]},
 			"faces": {
-				"north": {"uv": [6.5, 4, 8.498, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [7, 5, 4, 13], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [10.502, 4, 12.5, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [10, 12, 13, 4], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5, 4.998, 13, 3], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [14, 4.5, 6, 6.498], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6.5, 4, 8.498, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [7, 5, 4, 13], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [10.502, 4, 12.5, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [10, 12, 13, 4], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5, 4.998, 13, 3], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [14, 4.5, 6, 6.498], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -193,12 +193,12 @@
 			"to": [19, 2.40925, 11.47103],
 			"rotation": {"angle": 45, "axis": "x", "origin": [18, 0.2161, 7.98232]},
 			"faces": {
-				"north": {"uv": [6.5, 10, 8.5, 4], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [10, 9, 6, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [12, 1.5, 11, 4.32843], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [11, 10, 7, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8.5, 10, 10.5, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [14, 2.5, 13, 5.32843], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6.5, 10, 8.5, 4], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [10, 9, 6, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [12, 1.5, 11, 4.32843], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [11, 10, 7, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8.5, 10, 10.5, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [14, 2.5, 13, 5.32843], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/curse/magic_glass.json
+++ b/assets/tusb/models/item/mob/curse/magic_glass.json
@@ -10,12 +10,12 @@
 			"from": [7, 7.0005, 7],
 			"to": [9, 8.9995, 9],
 			"faces": {
-				"north": {"uv": [1, 13, 3, 14.999], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 2, 5, 2.999], "rotation": 90, "texture": "#0", "tintindex": 1},
-				"south": {"uv": [1, 13, 3, 14.999], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 2, 5, 2.999], "rotation": 90, "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 2, 5, 3], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 2, 5, 3], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [1, 13, 3, 14.999], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 2, 5, 2.999], "rotation": 90, "texture": "#0", "tintindex": 0},
+				"south": {"uv": [1, 13, 3, 14.999], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 2, 5, 2.999], "rotation": 90, "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 2, 5, 3], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 2, 5, 3], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -23,12 +23,12 @@
 			"to": [6.92892, 9, 14.82841],
 			"rotation": {"angle": 45, "axis": "y", "origin": [-1.48528, 0, 8.41421]},
 			"faces": {
-				"north": {"uv": [2, 0, 3, 5], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [2, 0, 3, 5], "texture": "#0", "tintindex": 1},
+				"north": {"uv": [2, 0, 3, 5], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [2, 0, 3, 5], "texture": "#0", "tintindex": 0},
 				"south": {"uv": [15, 0, 16, 5], "texture": "#1"},
 				"west": {"uv": [15, 0, 16, 5], "texture": "#1"},
-				"up": {"uv": [13.5, 0, 16, 2.5], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [13.5, 2.5, 16, 0], "texture": "#0", "tintindex": 1}
+				"up": {"uv": [13.5, 0, 16, 2.5], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [13.5, 2.5, 16, 0], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -37,11 +37,11 @@
 			"rotation": {"angle": -45, "axis": "y", "origin": [-1.48528, 0, 7.58579]},
 			"faces": {
 				"north": {"uv": [16, 0, 15, 5], "texture": "#1"},
-				"east": {"uv": [3, 0, 2, 5], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [3, 0, 2, 5], "texture": "#0", "tintindex": 1},
+				"east": {"uv": [3, 0, 2, 5], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [3, 0, 2, 5], "texture": "#0", "tintindex": 0},
 				"west": {"uv": [16, 0, 15, 5], "texture": "#1"},
-				"up": {"uv": [13.5, 2.5, 16, 0], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [13.5, 0, 16, 2.5], "texture": "#0", "tintindex": 1}
+				"up": {"uv": [13.5, 2.5, 16, 0], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [13.5, 0, 16, 2.5], "texture": "#0", "tintindex": 0}
 			}
 		}
 	]

--- a/assets/tusb/models/item/mob/curse/magic_stone.json
+++ b/assets/tusb/models/item/mob/curse/magic_stone.json
@@ -10,12 +10,12 @@
 			"from": [4, 4, 4],
 			"to": [12, 12, 12],
 			"faces": {
-				"north": {"uv": [0, 8, 8, 16], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [8, 8, 16, 0], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 16, 8, 8], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [8, 0, 16, 8], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 8], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [8, 0, 0, 8], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 8, 8, 16], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [8, 8, 16, 0], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 16, 8, 8], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [8, 0, 16, 8], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 8], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [8, 0, 0, 8], "texture": "#0", "tintindex": 0}
 			}
 		}
 	]

--- a/assets/tusb/models/item/mob/curse/magic_stone2.json
+++ b/assets/tusb/models/item/mob/curse/magic_stone2.json
@@ -10,12 +10,12 @@
 			"from": [6, 0, 6],
 			"to": [10, 16, 10],
 			"faces": {
-				"north": {"uv": [0, 0, 4, 16], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [4, 0, 0, 16], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 0, 4, 16], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [4, 0, 0, 16], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [4, 0, 8, 4], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [8, 4, 4, 8], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 0, 4, 16], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [4, 0, 0, 16], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 0, 4, 16], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [4, 0, 0, 16], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [4, 0, 8, 4], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [8, 4, 4, 8], "texture": "#0", "tintindex": 0}
 			}
 		}
 	]

--- a/assets/tusb/models/item/mob/curse/magic_stone4.json
+++ b/assets/tusb/models/item/mob/curse/magic_stone4.json
@@ -10,12 +10,12 @@
 			"to": [9.5, 9, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0, 7, 0]},
 			"faces": {
-				"north": {"uv": [15, 15, 16, 16], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [6, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [15, 15, 16, 16], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [6, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 0, 6, 12], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 0, 6, 12], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [15, 15, 16, 16], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [6, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [15, 15, 16, 16], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [6, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 0, 6, 12], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 0, 6, 12], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -23,12 +23,12 @@
 			"to": [9.96445, 8.9995, 12.36394],
 			"rotation": {"angle": 45, "axis": "y", "origin": [0.84315, 7, 9.24264]},
 			"faces": {
-				"north": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [6, 0, 12, 6], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [6, 0, 12, 6], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [6, 0, 12, 6], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [6, 0, 12, 6], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -36,12 +36,12 @@
 			"to": [9.96445, 8.9995, 5.75736],
 			"rotation": {"angle": -45, "axis": "y", "origin": [0.84315, 7, 6.75736]},
 			"faces": {
-				"north": {"uv": [12, 6, 10, 10], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [12, 6, 10, 10], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [12, 6, 10, 10], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [12, 6, 10, 10], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [6, 6, 12, 0], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [6, 6, 12, 0], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [12, 6, 10, 10], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [12, 6, 10, 10], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [12, 6, 10, 10], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [12, 6, 10, 10], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [6, 6, 12, 0], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [6, 6, 12, 0], "texture": "#0", "tintindex": 0}
 			}
 		}
 	]

--- a/assets/tusb/models/item/mob/curse/magic_stone5.json
+++ b/assets/tusb/models/item/mob/curse/magic_stone5.json
@@ -10,12 +10,12 @@
 			"to": [9.5, 9, 9],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0, 7, 0]},
 			"faces": {
-				"north": {"uv": [15, 15, 16, 16], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [6, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [6, 10, 12, 14], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [6, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 8, 6, 16], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 16, 6, 8], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [15, 15, 16, 16], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [6, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [6, 10, 12, 14], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [6, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 8, 6, 16], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 16, 6, 8], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -23,12 +23,12 @@
 			"to": [9.96445, 8.9995, 12.36394],
 			"rotation": {"angle": 45, "axis": "y", "origin": [0.84315, 7, 9.24264]},
 			"faces": {
-				"north": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [6, 0, 12, 6], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [6, 0, 12, 6], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [10, 6, 12, 10], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [6, 0, 12, 6], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [6, 0, 12, 6], "texture": "#0", "tintindex": 0}
 			}
 		}
 	]

--- a/assets/tusb/models/item/mob/fire_demon_wait.json
+++ b/assets/tusb/models/item/mob/fire_demon_wait.json
@@ -13,12 +13,12 @@
 			"to": [12.25, 23.75, 5.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [11.25, 2.75, 13.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.75, 10.75, 2, 11.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.75, 11.5, 2, 12.25], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5.5, 13.75, 3.25, 13.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.5, 13.75, 3.25, 14], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11.25, 2.75, 13.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.75, 10.75, 2, 11.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.75, 11.5, 2, 12.25], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5.5, 13.75, 3.25, 13.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.5, 13.75, 3.25, 14], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -27,12 +27,12 @@
 			"to": [12.75, 25, 7.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [4, 8.5, 6.5, 9.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14.75, 5.75, 15.25, 7], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.25, 5.75, 15.75, 7], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 7.5, 13, 7], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 7.5, 13, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [4, 8.5, 6.5, 9.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14.75, 5.75, 15.25, 7], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.25, 5.75, 15.75, 7], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 7.5, 13, 7], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 7.5, 13, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -41,12 +41,12 @@
 			"to": [13.5, 25.25, 15.375],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [0, 0, 2.75, 2], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.5, 0, 7.5, 2], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 2, 2.75, 4], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5.5, 2, 7.5, 4], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5.5, 2, 2.75, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.5, 2, 2.75, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 2.75, 2], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.5, 0, 7.5, 2], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 2, 2.75, 4], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5.5, 2, 7.5, 4], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5.5, 2, 2.75, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.5, 2, 2.75, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -55,12 +55,12 @@
 			"to": [9.25, 20, 7.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [5.5, 13.5, 6.25, 13.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.25, 11.5, 5.75, 11.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.75, 14, 1.25, 14.25], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.75, 14.25, 2, 13.75], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7.5, 15.5, 6.75, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [5.5, 13.5, 6.25, 13.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.25, 11.5, 5.75, 11.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.75, 14, 1.25, 14.25], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.75, 14.25, 2, 13.75], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7.5, 15.5, 6.75, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -69,12 +69,12 @@
 			"to": [8.5, 19.75, 6.125],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [8.5, 5.5, 8.75, 6.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 8.5, 8.75, 9.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3, 14.25, 3.25, 15.25], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5.75, 14.25, 6, 15.25], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [7.25, 12.75, 7, 12.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.25, 12.75, 5, 13], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8.5, 5.5, 8.75, 6.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 8.5, 8.75, 9.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3, 14.25, 3.25, 15.25], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5.75, 14.25, 6, 15.25], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [7.25, 12.75, 7, 12.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.25, 12.75, 5, 13], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -83,12 +83,12 @@
 			"to": [8.75, 19, 7.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [15.25, 0, 15.75, 0.25], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.25, 0.25, 15.75, 0.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.25, 0.5, 15.75, 0.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [7, 13, 6.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.5, 11.25, 2, 11.75], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [15.25, 0, 15.75, 0.25], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.25, 0.25, 15.75, 0.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.25, 0.5, 15.75, 0.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [7, 13, 6.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.5, 11.25, 2, 11.75], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -97,12 +97,12 @@
 			"to": [10.5, 18, 7.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [1.5, 15.5, 2.75, 15.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 15.25, 2, 15.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 14.5, 0.5, 14.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6.5, 13, 5.25, 12.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 1, 14.75, 1.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 15.5, 2.75, 15.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 15.25, 2, 15.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 14.5, 0.5, 14.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6.5, 13, 5.25, 12.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 1, 14.75, 1.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -111,12 +111,12 @@
 			"to": [11.5, 17, 13.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [13, 6.5, 14.75, 7], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [13.25, 1.5, 14.5, 2], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [13, 6, 14.75, 6.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [13.25, 2, 14.5, 2.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12.25, 7.75, 10.5, 9], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [13, 6.5, 14.75, 7], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [13.25, 1.5, 14.5, 2], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [13, 6, 14.75, 6.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [13.25, 2, 14.5, 2.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12.25, 7.75, 10.5, 9], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -125,12 +125,12 @@
 			"to": [11.5, 15, 12.375],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [14, 8, 15.75, 8.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 12.25, 2, 12.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [12.25, 8, 14, 8.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [13.5, 3, 15.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.75, 8.5, 0, 6.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3.5, 6.5, 1.75, 8.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14, 8, 15.75, 8.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 12.25, 2, 12.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [12.25, 8, 14, 8.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [13.5, 3, 15.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.75, 8.5, 0, 6.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3.5, 6.5, 1.75, 8.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -139,12 +139,12 @@
 			"to": [13, 17, 13.375],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [15.5, 7.5, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [12.25, 8.5, 14, 9], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [15.5, 7, 16, 7.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 8.5, 15.75, 9], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8.5, 13.5, 8, 11.75], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3.25, 12.5, 2.75, 14.25], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [15.5, 7.5, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [12.25, 8.5, 14, 9], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [15.5, 7, 16, 7.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 8.5, 15.75, 9], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8.5, 13.5, 8, 11.75], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3.25, 12.5, 2.75, 14.25], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -153,12 +153,12 @@
 			"to": [12, 18, 7.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [5.5, 13.75, 5.75, 14], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14.5, 1.5, 15, 1.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3.25, 14.5, 3.5, 14.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14.5, 1.75, 15, 2], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.75, 15, 0.5, 14.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [14.75, 2, 14.5, 2.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [5.5, 13.75, 5.75, 14], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14.5, 1.5, 15, 1.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3.25, 14.5, 3.5, 14.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14.5, 1.75, 15, 2], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.75, 15, 0.5, 14.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [14.75, 2, 14.5, 2.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -167,12 +167,12 @@
 			"to": [12, 19, 7.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [1.25, 13.5, 2, 13.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15, 1.5, 15.5, 1.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15, 1.75, 15.5, 2], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 14.25, 1.25, 13.75], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 13.75, 2, 14.25], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.25, 13.5, 2, 13.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15, 1.5, 15.5, 1.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15, 1.75, 15.5, 2], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 14.25, 1.25, 13.75], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 13.75, 2, 14.25], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -181,12 +181,12 @@
 			"to": [12, 20, 7.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [13.25, 2.5, 13.5, 2.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [4, 14.5, 4.5, 14.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [4, 14.5, 4.5, 14.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3.5, 15, 3.25, 14.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [4, 14.5, 3.75, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [13.25, 2.5, 13.5, 2.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [4, 14.5, 4.5, 14.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [4, 14.5, 4.5, 14.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3.5, 15, 3.25, 14.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [4, 14.5, 3.75, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -195,12 +195,12 @@
 			"to": [11.5, 21, 5.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [13.75, 5.75, 14.5, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9.25, 1.75, 9.5, 2], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3.5, 14.75, 3.75, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5.25, 14.75, 4.5, 14.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.25, 14.75, 4.5, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [13.75, 5.75, 14.5, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9.25, 1.75, 9.5, 2], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3.5, 14.75, 3.75, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5.25, 14.75, 4.5, 14.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.25, 14.75, 4.5, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -209,12 +209,12 @@
 			"to": [4.5, 17, 13.375],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [16, 7.5, 15.5, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.75, 8.5, 14, 9], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 7, 15.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14, 8.5, 12.25, 9], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 13.5, 8.5, 11.75], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 12.5, 3.25, 14.25], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 7.5, 15.5, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.75, 8.5, 14, 9], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 7, 15.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14, 8.5, 12.25, 9], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 13.5, 8.5, 11.75], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 12.5, 3.25, 14.25], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -223,12 +223,12 @@
 			"to": [5.25, 18, 7.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [5.75, 13.75, 5.5, 14], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15, 1.75, 14.5, 2], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3.5, 14.5, 3.25, 14.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15, 1.5, 14.5, 1.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 15, 0.75, 14.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [14.5, 2, 14.75, 2.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [5.75, 13.75, 5.5, 14], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15, 1.75, 14.5, 2], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3.5, 14.5, 3.25, 14.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15, 1.5, 14.5, 1.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 15, 0.75, 14.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [14.5, 2, 14.75, 2.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -237,12 +237,12 @@
 			"to": [7, 19, 7.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [2, 13.5, 1.25, 13.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 1.75, 15, 2], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 1.5, 15, 1.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.25, 14.25, 2, 13.75], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 13.75, 2.75, 14.25], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 13.5, 1.25, 13.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.5, 1.75, 15, 2], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.5, 1.5, 15, 1.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.25, 14.25, 2, 13.75], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 13.75, 2.75, 14.25], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -251,12 +251,12 @@
 			"to": [5, 20, 7.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [13.5, 2.5, 13.25, 2.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [4.5, 14.75, 4, 15], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [4.5, 14.75, 4, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3.25, 15, 3.5, 14.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3.75, 14.5, 4, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [13.5, 2.5, 13.25, 2.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [4.5, 14.75, 4, 15], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [4.5, 14.75, 4, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3.25, 15, 3.5, 14.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3.75, 14.5, 4, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -265,12 +265,12 @@
 			"to": [7.75, 21, 5.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [14.5, 5.75, 13.75, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3.75, 14.75, 3.5, 15], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9.5, 1.75, 9.25, 2], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [4.5, 14.75, 5.25, 14.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [4.5, 14.75, 5.25, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14.5, 5.75, 13.75, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3.75, 14.75, 3.5, 15], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9.5, 1.75, 9.25, 2], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [4.5, 14.75, 5.25, 14.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [4.5, 14.75, 5.25, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -279,12 +279,12 @@
 			"to": [13.25, 27, 6.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.75, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [13.25, 0, 14.25, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14.75, 0, 15.25, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [12.25, 0, 13.25, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14.25, 0, 14.75, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6.75, 16, 5.75, 15.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.75, 15.5, 4.75, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [13.25, 0, 14.25, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14.75, 0, 15.25, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [12.25, 0, 13.25, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14.25, 0, 14.75, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6.75, 16, 5.75, 15.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.75, 15.5, 4.75, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -293,12 +293,12 @@
 			"to": [14, 29, 6.375],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [11.25, 26, 5.5]},
 			"faces": {
-				"north": {"uv": [7.5, 9, 8.5, 9.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6.5, 9, 7, 9.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 12.75, 1, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7, 9, 7.5, 9.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [7.5, 9, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8.5, 8.5, 7.5, 9], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [7.5, 9, 8.5, 9.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6.5, 9, 7, 9.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 12.75, 1, 13.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7, 9, 7.5, 9.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [7.5, 9, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8.5, 8.5, 7.5, 9], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -307,12 +307,12 @@
 			"to": [14.5, 29.78246, 8.97208],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [11.25, 28.65746, 7.22208]},
 			"faces": {
-				"north": {"uv": [7.25, 12.5, 8, 13], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 14, 0.75, 14.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3.25, 14, 4, 14.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [4, 14, 4.75, 14.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 12.5, 7.25, 11.75], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.75, 5, 15, 5.75], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [7.25, 12.5, 8, 13], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 14, 0.75, 14.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3.25, 14, 4, 14.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [4, 14, 4.75, 14.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 12.5, 7.25, 11.75], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.75, 5, 15, 5.75], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -321,12 +321,12 @@
 			"to": [14.75, 30.36081, 12.37692],
 			"rotation": {"angle": 0, "axis": "x", "origin": [12.5, 29.13581, 9.12692]},
 			"faces": {
-				"north": {"uv": [4.75, 14, 5.5, 14.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 15.25, 1.5, 15.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [4.75, 15, 5.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5.75, 13.75, 6.75, 14.25], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [4, 13.5, 3.25, 12.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [14.5, 9, 13.75, 10], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [4.75, 14, 5.5, 14.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 15.25, 1.5, 15.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [4.75, 15, 5.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5.75, 13.75, 6.75, 14.25], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [4, 13.5, 3.25, 12.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [14.5, 9, 13.75, 10], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -335,12 +335,12 @@
 			"to": [14.25, 30.26081, 17.37692],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [13.5, 29.43581, 12.37692]},
 			"faces": {
-				"north": {"uv": [0.75, 14.25, 1.5, 14.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14.75, 3.5, 16, 4], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 14.25, 2.25, 14.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14.75, 4, 16, 4.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6.75, 15.5, 6, 14.25], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2.75, 12.5, 2, 13.75], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.75, 14.25, 1.5, 14.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14.75, 3.5, 16, 4], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 14.25, 2.25, 14.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14.75, 4, 16, 4.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6.75, 15.5, 6, 14.25], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2.75, 12.5, 2, 13.75], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -349,12 +349,12 @@
 			"to": [6.25, 27, 6.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [4.5, 25, 5.725]},
 			"faces": {
-				"north": {"uv": [14.25, 0, 13.25, 1], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14.75, 0, 14.25, 1], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [13.25, 0, 12.25, 1], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.25, 0, 14.75, 1], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5.75, 16, 6.75, 15.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [4.75, 15.5, 5.75, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14.25, 0, 13.25, 1], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14.75, 0, 14.25, 1], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [13.25, 0, 12.25, 1], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.25, 0, 14.75, 1], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5.75, 16, 6.75, 15.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [4.75, 15.5, 5.75, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -363,12 +363,12 @@
 			"to": [5.75, 29, 6.375],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [4.75, 26, 5.5]},
 			"faces": {
-				"north": {"uv": [8.5, 9, 7.5, 9.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [7.5, 9, 7, 9.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 12.75, 0, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7, 9, 6.5, 9.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6.5, 9, 7.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [7.5, 8.5, 8.5, 9], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8.5, 9, 7.5, 9.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [7.5, 9, 7, 9.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 12.75, 0, 13.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7, 9, 6.5, 9.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6.5, 9, 7.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [7.5, 8.5, 8.5, 9], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -377,12 +377,12 @@
 			"to": [4.75, 29.78246, 8.97208],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [4.75, 28.65746, 7.22208]},
 			"faces": {
-				"north": {"uv": [8, 12.5, 7.25, 13], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [4.75, 14, 4, 14.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [4, 14, 3.25, 14.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.75, 14, 0, 14.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [7.25, 12.5, 8, 11.75], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15, 5, 15.75, 5.75], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 12.5, 7.25, 13], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [4.75, 14, 4, 14.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [4, 14, 3.25, 14.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.75, 14, 0, 14.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [7.25, 12.5, 8, 11.75], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15, 5, 15.75, 5.75], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -391,12 +391,12 @@
 			"to": [3.75, 30.36081, 12.37692],
 			"rotation": {"angle": 0, "axis": "x", "origin": [3.5, 29.13581, 9.12692]},
 			"faces": {
-				"north": {"uv": [5.5, 14, 4.75, 14.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6.75, 13.75, 5.75, 14.25], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [5.5, 15, 4.75, 15.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 15.25, 0.5, 15.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3.25, 13.5, 4, 12.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [13.75, 9, 14.5, 10], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [5.5, 14, 4.75, 14.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6.75, 13.75, 5.75, 14.25], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [5.5, 15, 4.75, 15.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 15.25, 0.5, 15.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3.25, 13.5, 4, 12.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [13.75, 9, 14.5, 10], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -405,12 +405,12 @@
 			"to": [4.25, 30.26081, 17.37692],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [2.5, 29.43581, 12.37692]},
 			"faces": {
-				"north": {"uv": [1.5, 14.25, 0.75, 14.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 4, 14.75, 4.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.25, 14.25, 1.5, 14.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 3.5, 14.75, 4], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 15.5, 6.75, 14.25], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 12.5, 2.75, 13.75], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 14.25, 0.75, 14.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 4, 14.75, 4.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.25, 14.25, 1.5, 14.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 3.5, 14.75, 4], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 15.5, 6.75, 14.25], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 12.5, 2.75, 13.75], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -419,12 +419,12 @@
 			"to": [11.5, 17.75, 5.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [10, 16, 5.5]},
 			"faces": {
-				"north": {"uv": [9, 13.5, 11.25, 15.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11.25, 13.5, 9, 15.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 13.5, 11.25, 15.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11.25, 13.5, 9, 15.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -433,12 +433,12 @@
 			"to": [9.5, 16.25, 5.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [10, 16, 5.5]},
 			"faces": {
-				"north": {"uv": [9, 13.5, 11.25, 15.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11.25, 13.5, 9, 15.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 13.5, 11.25, 15.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11.25, 13.5, 9, 15.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -447,12 +447,12 @@
 			"to": [5.5, 17.75, 5.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [6, 16, 5.5]},
 			"faces": {
-				"north": {"uv": [11.25, 13.5, 9, 15.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 13.5, 11.25, 15.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11.25, 13.5, 9, 15.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 13.5, 11.25, 15.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -461,12 +461,12 @@
 			"to": [7.5, 16.25, 5.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [6, 16, 5.5]},
 			"faces": {
-				"north": {"uv": [11.25, 13.5, 9, 15.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 13.5, 11.25, 15.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11.25, 13.5, 9, 15.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 13.5, 11.25, 15.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -475,12 +475,12 @@
 			"to": [6.5, 16.75, 6.75],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 15.75, 5.5]},
 			"faces": {
-				"north": {"uv": [9, 13.5, 11.25, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11.25, 13.5, 9, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 13.5, 11.25, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11.25, 13.5, 9, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -489,12 +489,12 @@
 			"to": [7.5, 16.75, 6.5],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 15.75, 5.5]},
 			"faces": {
-				"north": {"uv": [9, 13.5, 11.25, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11.25, 13.5, 9, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 13.5, 11.25, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11.25, 13.5, 9, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -503,12 +503,12 @@
 			"to": [10.5, 16.75, 6.75],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 15.75, 5.5]},
 			"faces": {
-				"north": {"uv": [11.25, 13.5, 9, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 13.5, 11.25, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11.25, 13.5, 9, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 13.5, 11.25, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -517,12 +517,12 @@
 			"to": [9.5, 16.75, 6.5],
 			"rotation": {"angle": 0, "axis": "z", "origin": [8, 15.75, 5.5]},
 			"faces": {
-				"north": {"uv": [11.25, 13.5, 9, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 13.5, 11.25, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11.25, 13.5, 9, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 13.5, 11.25, 15.75], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -531,12 +531,12 @@
 			"to": [23, 15.25, 14.125],
 			"rotation": {"angle": -45, "axis": "x", "origin": [19, 11.25, 10.375]},
 			"faces": {
-				"north": {"uv": [3.5, 6.5, 5.25, 8.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.25, 6.5, 7, 8.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [7, 6.5, 8.75, 8.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7.5, 0, 9.25, 2], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [10.5, 7.25, 8.75, 5.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10.5, 7.25, 8.75, 9], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [3.5, 6.5, 5.25, 8.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.25, 6.5, 7, 8.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [7, 6.5, 8.75, 8.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7.5, 0, 9.25, 2], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [10.5, 7.25, 8.75, 5.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10.5, 7.25, 8.75, 9], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -545,12 +545,12 @@
 			"to": [21, 14.75, 7.125],
 			"rotation": {"angle": -45, "axis": "x", "origin": [19, 11.25, 10.375]},
 			"faces": {
-				"north": {"uv": [10.5, 6, 11.75, 7.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6.75, 13.5, 8.5, 15.25], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9.25, 0, 11, 1.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [13, 7.75, 11.75, 6], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12.25, 0, 11, 1.75], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [10.5, 6, 11.75, 7.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6.75, 13.5, 8.5, 15.25], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9.25, 0, 11, 1.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [13, 7.75, 11.75, 6], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12.25, 0, 11, 1.75], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -559,12 +559,12 @@
 			"to": [25, 7.75, 4.125],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [19, 11.25, 10.375]},
 			"faces": {
-				"north": {"uv": [0, 4, 4.25, 5.25], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [13.75, 4.5, 15, 5.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [4.25, 4, 8.5, 5.25], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [4, 11.5, 5.25, 12.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [4.25, 6.5, 0, 5.25], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8.5, 5.25, 4.25, 6.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 4, 4.25, 5.25], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [13.75, 4.5, 15, 5.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [4.25, 4, 8.5, 5.25], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [4, 11.5, 5.25, 12.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [4.25, 6.5, 0, 5.25], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8.5, 5.25, 4.25, 6.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -573,12 +573,12 @@
 			"to": [0, 15, 14.375],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [-3, 11.25, 10.375]},
 			"faces": {
-				"north": {"uv": [8.75, 7.25, 10.5, 5.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9.25, 0, 7.5, 2], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8.75, 7.25, 10.5, 9], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7, 6.5, 5.25, 8.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8.75, 6.5, 7, 8.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.25, 6.5, 3.5, 8.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8.75, 7.25, 10.5, 5.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9.25, 0, 7.5, 2], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8.75, 7.25, 10.5, 9], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7, 6.5, 5.25, 8.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8.75, 6.5, 7, 8.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.25, 6.5, 3.5, 8.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -587,12 +587,12 @@
 			"to": [0, 8, 13.875],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [-3, 11.25, 10.375]},
 			"faces": {
-				"north": {"uv": [11.75, 7.75, 13, 6], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [11, 0, 9.25, 1.75], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11, 0, 12.25, 1.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 13.5, 6.75, 15.25], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [11.75, 6, 10.5, 7.75], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11.75, 7.75, 13, 6], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [11, 0, 9.25, 1.75], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11, 0, 12.25, 1.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 13.5, 6.75, 15.25], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [11.75, 6, 10.5, 7.75], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -601,12 +601,12 @@
 			"to": [9.6058, 6.16343, 7.875],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [-4.3942, 6.66343, 1.625]},
 			"faces": {
-				"north": {"uv": [4.25, 4, 0, 5.25], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.25, 11.5, 4, 12.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8.5, 4, 4.25, 5.25], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15, 4.5, 13.75, 5.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 6.5, 4.25, 5.25], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [4.25, 5.25, 8.5, 6.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [4.25, 4, 0, 5.25], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.25, 11.5, 4, 12.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8.5, 4, 4.25, 5.25], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15, 4.5, 13.75, 5.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 6.5, 4.25, 5.25], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [4.25, 5.25, 8.5, 6.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -615,12 +615,12 @@
 			"to": [12, 3, 12.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [2, 11.75, 4, 12.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 12.75, 2, 13.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [5.25, 11.75, 7.25, 12.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [4, 12.75, 5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [13.25, 1.75, 11.25, 2.75], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 11.75, 4, 12.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 12.75, 2, 13.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [5.25, 11.75, 7.25, 12.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [4, 12.75, 5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [13.25, 1.75, 11.25, 2.75], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -629,12 +629,12 @@
 			"to": [13, 5, 13.125],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [12.25, 1, 14.75, 1.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15, 4.5, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [13.5, 2.5, 16, 3], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14.75, 2, 15.75, 2.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [13, 3.5, 10.5, 4.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [12.25, 1, 14.75, 1.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15, 4.5, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [13.5, 2.5, 16, 3], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14.75, 2, 15.75, 2.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [13, 3.5, 10.5, 4.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -643,12 +643,12 @@
 			"to": [8.5, 5, 14.125],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [8.75, 7.25, 9, 8.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.25, 14.25, 2.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 14.25, 2.75, 15.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.75, 14.25, 3, 15.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [3.75, 14.75, 3.5, 14.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [14.75, 3.5, 14.5, 3.75], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8.75, 7.25, 9, 8.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.25, 14.25, 2.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 14.25, 2.75, 15.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.75, 14.25, 3, 15.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [3.75, 14.75, 3.5, 14.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [14.75, 3.5, 14.5, 3.75], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -657,12 +657,12 @@
 			"to": [8.5, 13, 14.625],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [8.5, 11.75, 8.75, 13.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.75, 9.75, 7.25, 11.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8.5, 13.75, 8.75, 15.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [7.25, 9.75, 8.75, 11.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 6.5, 15.75, 5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [5.75, 14, 5.5, 15.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8.5, 11.75, 8.75, 13.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.75, 9.75, 7.25, 11.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8.5, 13.75, 8.75, 15.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [7.25, 9.75, 8.75, 11.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 6.5, 15.75, 5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [5.75, 14, 5.5, 15.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -671,12 +671,12 @@
 			"to": [14, 7, 13.625],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [13, 3.5, 14.5, 4], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [13, 4, 14.5, 4.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [5, 13, 6.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6.5, 13, 8, 13.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [4, 11.75, 2.5, 10.25], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12, 4.5, 10.5, 6], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [13, 3.5, 14.5, 4], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [13, 4, 14.5, 4.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [5, 13, 6.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6.5, 13, 8, 13.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [4, 11.75, 2.5, 10.25], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12, 4.5, 10.5, 6], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -685,12 +685,12 @@
 			"to": [16, 14, 13.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [7.5, 2, 9.5, 3.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9.5, 1.75, 11.25, 3.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 8.5, 2, 10.25], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [4, 9.75, 5.75, 11.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [4, 10.25, 2, 8.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10.5, 3.75, 8.5, 5.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [7.5, 2, 9.5, 3.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9.5, 1.75, 11.25, 3.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 8.5, 2, 10.25], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [4, 9.75, 5.75, 11.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [4, 10.25, 2, 8.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10.5, 3.75, 8.5, 5.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -699,12 +699,12 @@
 			"to": [16, 14, 14.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0, 0, -1]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.25, 14.75, 0.5, 15.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [3.25, 15, 4.75, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 14.75, 0.25, 15.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 15.75, 1.5, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1.5, 15.75, 3, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.25, 14.75, 0.5, 15.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [3.25, 15, 4.75, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 14.75, 0.25, 15.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 15.75, 1.5, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1.5, 15.75, 3, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -713,12 +713,12 @@
 			"to": [7.5, 7, 13.625],
 			"rotation": {"angle": 0, "axis": "y", "origin": [4.25, 8.25, 10.5625]},
 			"faces": {
-				"north": {"uv": [14.5, 3.5, 13, 4], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 13, 6.5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6.5, 13, 5, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14.5, 4, 13, 4.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2.5, 11.75, 4, 10.25], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10.5, 4.5, 12, 6], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14.5, 3.5, 13, 4], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 13, 6.5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6.5, 13, 5, 13.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14.5, 4, 13, 4.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2.5, 11.75, 4, 10.25], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10.5, 4.5, 12, 6], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -727,12 +727,12 @@
 			"to": [7.5, 14, 13.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [4.25, 8.25, 10.5625]},
 			"faces": {
-				"north": {"uv": [9.5, 2, 7.5, 3.75], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.75, 9.75, 4, 11.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 8.5, 0, 10.25], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [11.25, 1.75, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 10.25, 4, 8.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8.5, 3.75, 10.5, 5.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9.5, 2, 7.5, 3.75], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.75, 9.75, 4, 11.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 8.5, 0, 10.25], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [11.25, 1.75, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 10.25, 4, 8.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8.5, 3.75, 10.5, 5.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -741,12 +741,12 @@
 			"to": [6, 14, 14.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0, 0, -0.125]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.25, 14.75, 0, 15.75], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [4.75, 15, 3.25, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 14.75, 0.25, 15.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 15.75, 1.5, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3, 15.75, 1.5, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.25, 14.75, 0, 15.75], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [4.75, 15, 3.25, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 14.75, 0.25, 15.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 15.75, 1.5, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3, 15.75, 1.5, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -755,12 +755,12 @@
 			"to": [10.25, -3.5, 12.625],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [1, 14.75, 2.25, 15.25], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 11.75, 0.5, 12.25], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 10.75, 3.25, 11.25], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.75, 11.25, 3.25, 11.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1.75, 12.25, 0.5, 11.75], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [3.25, 10.25, 2, 10.75], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 14.75, 2.25, 15.25], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 11.75, 0.5, 12.25], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 10.75, 3.25, 11.25], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.75, 11.25, 3.25, 11.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1.75, 12.25, 0.5, 11.75], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [3.25, 10.25, 2, 10.75], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -769,12 +769,12 @@
 			"to": [11.5, -0.25, 12.375],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [0, 10.25, 1.75, 11], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [3.25, 10.25, 4, 11], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 11, 1.75, 11.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [3.25, 11, 4, 11.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [13.75, 5.25, 12, 4.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [13.75, 5.25, 12, 6], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 10.25, 1.75, 11], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [3.25, 10.25, 4, 11], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 11, 1.75, 11.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [3.25, 11, 4, 11.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [13.75, 5.25, 12, 4.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [13.75, 5.25, 12, 6], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -783,12 +783,12 @@
 			"to": [9.75, -5.5, 12.875],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 15.5, 9.4375]},
 			"faces": {
-				"north": {"uv": [7.5, 3.75, 8.5, 4], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 11.25, 2.75, 11.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9.5, 3.5, 10.5, 3.75], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 11.5, 2.75, 11.75], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [13.25, 1.75, 12.25, 1.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [13, 5, 12, 5.25], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [7.5, 3.75, 8.5, 4], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 11.25, 2.75, 11.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9.5, 3.5, 10.5, 3.75], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 11.5, 2.75, 11.75], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [13.25, 1.75, 12.25, 1.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [13, 5, 12, 5.25], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -797,12 +797,12 @@
 			"to": [-2.46967, 19, 20.42678],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [-2.5, 12.5, 20.25]},
 			"faces": {
-				"north": {"uv": [11.25, 9, 8.75, 13], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8.75, 9, 11.25, 13], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11.25, 9, 8.75, 13], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8.75, 9, 11.25, 13], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -811,12 +811,12 @@
 			"to": [3.38388, 19, 14.57322],
 			"rotation": {"angle": 45, "axis": "y", "origin": [3.5, 12.5, 14.75]},
 			"faces": {
-				"north": {"uv": [13.75, 9, 11.25, 13], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11.25, 9, 13.75, 13], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [13.75, 9, 11.25, 13], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11.25, 9, 13.75, 13], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -825,12 +825,12 @@
 			"to": [26.46967, 19, 20.42678],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [18.5, 12.5, 20.25]},
 			"faces": {
-				"north": {"uv": [8.75, 9, 11.25, 13], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [11.25, 9, 8.75, 13], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8.75, 9, 11.25, 13], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [11.25, 9, 8.75, 13], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -839,12 +839,12 @@
 			"to": [20.61612, 19, 14.57322],
 			"rotation": {"angle": -45, "axis": "y", "origin": [12.5, 12.5, 14.75]},
 			"faces": {
-				"north": {"uv": [11.25, 9, 13.75, 13], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [13.75, 9, 11.25, 13], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [11.25, 9, 13.75, 13], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [13.75, 9, 11.25, 13], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{

--- a/assets/tusb/models/item/mob/garbage_can_demon.json
+++ b/assets/tusb/models/item/mob/garbage_can_demon.json
@@ -12,12 +12,12 @@
 			"to": [16, 19, 16],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 18, 16]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 0.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [7.5, 0, 8, 8], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 7.5, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0.5, 8], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 0.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [7.5, 0, 8, 8], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 7.5, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0.5, 8], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -26,12 +26,12 @@
 			"to": [14, 20, 14],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 18, 16]},
 			"faces": {
-				"north": {"uv": [1, 1, 7, 1.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6.5, 1, 7, 7], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 6.5, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 1, 1.5, 7], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 1, 7, 1.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6.5, 1, 7, 7], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 6.5, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 1, 1.5, 7], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [1, 1, 7, 7], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [12, 22, 9],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 18, 16]},
 			"faces": {
-				"north": {"uv": [6, 3.5, 2, 4], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 3.5, 2.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 4, 6, 4.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5.5, 3.5, 6, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 3.5, 6, 4.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 4.5, 6, 3.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 3.5, 2, 4], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 3.5, 2.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 4, 6, 4.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5.5, 3.5, 6, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 3.5, 6, 4.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 4.5, 6, 3.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [12, 21, 9],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 18, 16]},
 			"faces": {
-				"north": {"uv": [2.5, 5, 3, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 3.5, 2.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 2.5, 3, 3], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [5.5, 3.5, 6, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [5.5, 3.5, 6, 4.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 5, 3, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 3.5, 2.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 2.5, 3, 3], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [5.5, 3.5, 6, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [5.5, 3.5, 6, 4.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [5, 21, 9],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 18, 16]},
 			"faces": {
-				"north": {"uv": [5, 5, 5.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [5.5, 3.5, 6, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [5, 2.5, 5.5, 3], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 3.5, 2.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 3.5, 2.5, 4.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [5, 5, 5.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [5.5, 3.5, 6, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [5, 2.5, 5.5, 3], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 3.5, 2.5, 4.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 3.5, 2.5, 4.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [0, 16, 10],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [0, 16, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 0, 9, 2], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 0, 9, 2], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 0, 9, 2], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 0, 9, 2], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [16, 16, 10],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [16, 16, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 0, 9, 2], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 0, 9, 2], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 0, 9, 2], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 0, 9, 2], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [16, 18, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0, -7, 0]},
 			"faces": {
-				"north": {"uv": [8, 4, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 4, 8.5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 4, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 4, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8, 4, 16, 4.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 4.5, 16, 5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 4, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 4, 8.5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 4, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.5, 4, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8, 4, 16, 4.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 4.5, 16, 5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [16, 18, 1],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0, -7, 0]},
 			"faces": {
-				"north": {"uv": [16, 4, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 4, 16, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 4, 8, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 4, 8.5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 4, 8, 4.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 4.5, 16, 5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 4, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.5, 4, 16, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 4, 8, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 4, 8.5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 4, 8, 4.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 4.5, 16, 5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [16, 18, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0, -7, 0]},
 			"faces": {
-				"north": {"uv": [9, 4, 8.5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 4, 8.5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [15.5, 4, 15, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 4, 8.5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8.5, 4.5, 15.5, 4], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 5, 8.5, 4.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 4, 8.5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.5, 4, 8.5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [15.5, 4, 15, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.5, 4, 8.5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8.5, 4.5, 15.5, 4], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 5, 8.5, 4.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [1, 18, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0.5, 17, 8]},
 			"faces": {
-				"north": {"uv": [9, 4, 8.5, 5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 4, 15.5, 5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [15.5, 4, 15, 5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 4, 15.5, 5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 4.5, 8.5, 4], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8.5, 5, 15.5, 4.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 4, 8.5, 5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 4, 15.5, 5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [15.5, 4, 15, 5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 4, 15.5, 5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 4.5, 8.5, 4], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8.5, 5, 15.5, 4.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [15, 16, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 5.5, 8]},
 			"faces": {
-				"north": {"uv": [14.5, 0, 9.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15, 5, 15.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8.5, 5, 15.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8.5, 5, 9, 15.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8.5, 5, 15.5, 5.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8.5, 15, 15.5, 15.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14.5, 0, 9.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15, 5, 15.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8.5, 5, 15.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8.5, 5, 9, 15.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8.5, 5, 15.5, 5.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8.5, 15, 15.5, 15.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -180,12 +180,12 @@
 			"to": [15, 16, 2],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 5.5, 8]},
 			"faces": {
-				"north": {"uv": [8.5, 5, 15.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8.5, 5, 9, 15.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14.5, 0, 9.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15, 5, 15.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8.5, 5, 15.5, 5.5], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8.5, 15, 15.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8.5, 5, 15.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8.5, 5, 9, 15.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14.5, 0, 9.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15, 5, 15.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8.5, 5, 15.5, 5.5], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8.5, 15, 15.5, 15.5], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [2, 16, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 5.5, 8]},
 			"faces": {
-				"north": {"uv": [9, 5, 9.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [14.5, 0, 9.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [14.5, 5, 15, 15.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 5, 15, 15.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 5, 15, 5.5], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 15, 15, 15.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 5, 9.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [14.5, 0, 9.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [14.5, 5, 15, 15.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 5, 15, 15.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 5, 15, 5.5], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 15, 15, 15.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -208,12 +208,12 @@
 			"to": [15, 16, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 5.5, 8]},
 			"faces": {
-				"north": {"uv": [14.5, 5, 15, 15.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 5, 15, 15.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 5, 9.5, 15.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [14.5, 0, 9.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 5, 15, 5.5], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 15, 15, 15.5], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [14.5, 5, 15, 15.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 5, 15, 15.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 5, 9.5, 15.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [14.5, 0, 9.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 5, 15, 5.5], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 15, 15, 15.5], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -222,12 +222,12 @@
 			"to": [14, -5, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 20.75, 8]},
 			"faces": {
-				"north": {"uv": [9, 15.5, 15, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 15.5, 15, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 15.5, 15, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 15.5, 15, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [14.5, 0, 9.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 15.5, 15, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 15.5, 15, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 15.5, 15, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 15.5, 15, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [14.5, 0, 9.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [1, 9, 7, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -278,12 +278,12 @@
 			"to": [11, 21.7, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17.5, 8]},
 			"faces": {
-				"north": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -292,12 +292,12 @@
 			"to": [12, 21, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17.5, 8]},
 			"faces": {
-				"north": {"uv": [9, 0.5, 15, 4], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 0.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 0.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 0.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 0.5, 15, 4], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 0.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 0.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 0.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9.5, 0, 14.5, 0.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -306,12 +306,12 @@
 			"to": [13, 16, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0.5, -12.5, 0.5]},
 			"faces": {
-				"north": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -320,12 +320,12 @@
 			"to": [12, 18.25, 0],
 			"rotation": {"angle": 0, "axis": "y", "origin": [12, 16.625, -0.125]},
 			"faces": {
-				"north": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 0.5, 9.5, 1], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 0.5, 9.5, 1], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -334,12 +334,12 @@
 			"to": [12, 18.25, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [12, 16.625, -0.125]},
 			"faces": {
-				"north": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -348,12 +348,12 @@
 			"to": [12, 17.75, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [12, 16.625, -0.125]},
 			"faces": {
-				"north": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -362,12 +362,12 @@
 			"to": [6, 18.25, 0],
 			"rotation": {"angle": 0, "axis": "y", "origin": [12, 16.625, -0.125]},
 			"faces": {
-				"north": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 0.5, 9.5, 1], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 0.5, 9.5, 1], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -376,12 +376,12 @@
 			"to": [6, 18.25, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [12, 16.625, -0.125]},
 			"faces": {
-				"north": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 4, 10, 0.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -390,12 +390,12 @@
 			"to": [6, 17.75, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [12, 16.625, -0.125]},
 			"faces": {
-				"north": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [9, 4, 9.5, 3.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 3.5, 9.5, 4], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/heavenly_messenger.json
+++ b/assets/tusb/models/item/mob/heavenly_messenger.json
@@ -18,8 +18,8 @@
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -32,8 +32,8 @@
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -46,8 +46,8 @@
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -60,8 +60,8 @@
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -74,8 +74,8 @@
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -88,8 +88,8 @@
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -102,8 +102,8 @@
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -114,10 +114,10 @@
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -128,10 +128,10 @@
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -142,10 +142,10 @@
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -158,8 +158,8 @@
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -172,8 +172,8 @@
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -185,9 +185,9 @@
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"west": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -199,9 +199,9 @@
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"west": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -213,9 +213,9 @@
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"west": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -224,12 +224,12 @@
 			"to": [20, 7, -4],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -238,12 +238,12 @@
 			"to": [28, 7, -4],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -253,11 +253,11 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -267,11 +267,11 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -281,11 +281,11 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -295,11 +295,11 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -308,12 +308,12 @@
 			"to": [12, 7, -4],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -322,12 +322,12 @@
 			"to": [4, 7, -4],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -336,12 +336,12 @@
 			"to": [-4, 7, -4],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"west": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -352,10 +352,10 @@
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"south": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -365,9 +365,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3"}
 			}
@@ -379,9 +379,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 15], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3"}
 			}
@@ -393,9 +393,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3"}
 			}
@@ -407,9 +407,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3"}
 			}
@@ -421,9 +421,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 15], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3"}
 			}
@@ -434,9 +434,9 @@
 			"to": [20, 8, -12.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -448,9 +448,9 @@
 			"to": [28, 8, -12.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 15], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -462,9 +462,9 @@
 			"to": [12, 8, -12.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -476,9 +476,9 @@
 			"to": [4, 8, -12.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -490,9 +490,9 @@
 			"to": [-4, 8, -12.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 15], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -505,9 +505,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"}
 			}
@@ -519,9 +519,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 15], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"}
 			}
@@ -533,9 +533,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"}
 			}
@@ -547,9 +547,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"}
 			}
@@ -561,9 +561,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 15], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"}
 			}
@@ -574,9 +574,9 @@
 			"to": [4, 8, 28.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"}
@@ -588,9 +588,9 @@
 			"to": [-4, 8, 28.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 15], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"}
@@ -602,9 +602,9 @@
 			"to": [12, 8, 28.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"}
@@ -616,9 +616,9 @@
 			"to": [20, 8, 28.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"}
@@ -630,9 +630,9 @@
 			"to": [28, 8, 28.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 15], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"}

--- a/assets/tusb/models/item/mob/huge_vase_0.json
+++ b/assets/tusb/models/item/mob/huge_vase_0.json
@@ -12,12 +12,12 @@
 			"to": [18, 31.5, 18],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -26,12 +26,12 @@
 			"to": [16, 29.5, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [20, 23.5, 20],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 1, 15, 7], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 9, 15, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 1, 15, 7], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 9, 15, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [22, 21.5, 22],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8.5, 0.5, 15.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8.5, 0.5, 15.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [20, 13.5, 20],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 9, 15, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 9, 15, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [18, 9.5, 18],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [16, 7.5, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10, 10, 14, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10, 10, 14, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [14, 3.5, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10.5, 10.5, 13.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10.5, 10.5, 13.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [-3.5, 27.5, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 21.5, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [27.5, 27.5, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 21.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [27.5, 27.5, 8],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 21.5, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [-3.5, 27.5, 8],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 21.5, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/large_vase_0.json
+++ b/assets/tusb/models/item/mob/large_vase_0.json
@@ -12,12 +12,12 @@
 			"to": [13, 16, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -26,12 +26,12 @@
 			"to": [12, 15, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [14, 12, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 1, 15, 7], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 9, 15, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 1, 15, 7], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 9, 15, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [15, 11, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8.5, 0.5, 15.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8.5, 0.5, 15.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [14, 7, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 9, 15, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 9, 15, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [13, 5, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [12, 4, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10, 10, 14, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10, 10, 14, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [11, 2, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10.5, 10.5, 13.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10.5, 10.5, 13.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [2.25, 14, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 080, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 080, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [17.75, 14, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [17.75, 14, 8],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [2.25, 14, 8],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 080, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 080, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/large_vase_1.json
+++ b/assets/tusb/models/item/mob/large_vase_1.json
@@ -12,12 +12,12 @@
 			"to": [13, 16, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -26,12 +26,12 @@
 			"to": [12, 15, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [14, 12, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 1, 15, 7], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 9, 15, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [9, 1, 15, 7], "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [9, 9, 15, 15], "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [15, 11, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8.5, 0.5, 15.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [8.5, 0.5, 15.5, 7.5], "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "rotation": 270, "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [14, 7, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 9, 15, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [9, 9, 15, 15], "rotation": 270, "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [13, 5, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [12, 4, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10, 10, 14, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [10, 10, 14, 14], "rotation": 270, "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [11, 2, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10.5, 10.5, 13.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [10.5, 10.5, 13.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [2.25, 14, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [17.75, 14, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [17.75, 14, 8],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [2.25, 14, 8],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex":0},
+				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex":0},
+				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex":0},
+				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex":0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex":0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex":0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/large_vase_2.json
+++ b/assets/tusb/models/item/mob/large_vase_2.json
@@ -12,12 +12,12 @@
 			"to": [13, 16, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 8, 6.5, 8.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -26,12 +26,12 @@
 			"to": [12, 15, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 8.5, 6, 10], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -40,12 +40,12 @@
 			"to": [14, 12, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [9, 1, 15, 7], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 9, 15, 15], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 10, 7, 10.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [9, 1, 15, 7], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 9, 15, 15], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -54,12 +54,12 @@
 			"to": [15, 11, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [8.5, 0.5, 15.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0.5, 10.5, 7.5, 12.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [8.5, 0.5, 15.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -68,12 +68,12 @@
 			"to": [14, 7, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9, 9, 15, 15], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 12.5, 7, 13.5], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9, 9, 15, 15], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -82,12 +82,12 @@
 			"to": [13, 5, 13],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1.5, 13.5, 6.5, 14], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [9.5, 9.5, 14.5, 14.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -96,12 +96,12 @@
 			"to": [12, 4, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10, 10, 14, 14], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 14, 6, 15], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10, 10, 14, 14], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [11, 2, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0.5, 8]},
 			"faces": {
-				"north": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [10.5, 10.5, 13.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2.5, 15, 5.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [10.5, 10.5, 13.5, 13.5], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -124,12 +124,12 @@
 			"to": [2.25, 14, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -138,12 +138,12 @@
 			"to": [17.75, 14, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -152,12 +152,12 @@
 			"to": [17.75, 14, 8],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -166,12 +166,12 @@
 			"to": [2.25, 14, 8],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 11, 8]},
 			"faces": {
-				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 1, 8, 3.5], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 15.5, 15.5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 1, 2, 3.5], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [15.5, 15.5, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [15.5, 15.5, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/magic_cannon_salute_donchian.json
+++ b/assets/tusb/models/item/mob/magic_cannon_salute_donchian.json
@@ -13,12 +13,12 @@
 			"to": [11.60394, 19.09727, 11.25299],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [8, 0, 15, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 0, 15, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 15, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 0, 15, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 0, 15, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 0, 15, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 15, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 0, 15, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -27,12 +27,12 @@
 			"to": [8.7, 3.84727, 2.34905],
 			"rotation": {"angle": 0, "axis": "x", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [6, 10, 8, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 10, 8, 14], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 10, 8, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 10, 8, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 10, 8, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 10, 8, 14], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 10, 8, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 10, 8, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -41,12 +41,12 @@
 			"to": [8.7, 1.23477, 4.96155],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 10, 8, 14], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 10, 8, 14], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 10, 8, 14], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6, 10, 8, 14], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 10, 8, 14], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 10, 8, 14], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 10, 8, 14], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6, 10, 8, 14], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -55,12 +55,12 @@
 			"to": [8.8125, 1.34727, 2.46155],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6, 14, 8, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -69,12 +69,12 @@
 			"to": [12.02481, 29.75413, 10.70886],
 			"rotation": {"angle": -45, "axis": "z", "origin": [8.06, 23.04182, 7.7]},
 			"faces": {
-				"north": {"uv": [2, 9.5, 8, 10], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 10, 6, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 9.5, 8, 10], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 16, 6, 10], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [2, 9.5, 8, 10], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [2, 9.5, 8, 10], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 9.5, 8, 10], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 10, 6, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 9.5, 8, 10], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 16, 6, 10], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [2, 9.5, 8, 10], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [2, 9.5, 8, 10], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -83,12 +83,12 @@
 			"to": [12.0625, 21.09727, 11.71155],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 8, 8, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 8, 8, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -97,12 +97,12 @@
 			"to": [11.5625, 3.09727, 11.21155],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [1, 8, 8, 9], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [1, 8, 8, 9], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [1, 8, 8, 9], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [1, 8, 8, 9], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0.5, 0.5, 7.5, 7.5], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0.5, 0.5, 7.5, 7.5], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [1, 8, 8, 9], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [1, 8, 8, 9], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [1, 8, 8, 9], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [1, 8, 8, 9], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0.5, 0.5, 7.5, 7.5], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0.5, 0.5, 7.5, 7.5], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -111,12 +111,12 @@
 			"to": [12.0625, 2.09727, 11.71155],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 8, 8, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 8, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 8, 8, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -125,12 +125,12 @@
 			"to": [11.0625, 0.09727, 10.71155],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [2, 9.5, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [2, 9.5, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [2, 9.5, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [2, 9.5, 8, 10], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 10, 6, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [2, 9.5, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [2, 9.5, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [2, 9.5, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [2, 9.5, 8, 10], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 10, 6, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -139,12 +139,12 @@
 			"to": [13.0625, 1.59727, 4.71155],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -153,12 +153,12 @@
 			"to": [5.0625, 1.59727, 4.71155],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -167,12 +167,12 @@
 			"to": [5.0625, 1.59727, 12.71155],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -181,12 +181,12 @@
 			"to": [13.0625, 1.59727, 12.71155],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8.125, 11.44454, 7.4231]},
 			"faces": {
-				"north": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [6, 14, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{

--- a/assets/tusb/models/item/mob/magic_circle.json
+++ b/assets/tusb/models/item/mob/magic_circle.json
@@ -11,12 +11,12 @@
 			"to": [9.59, 8.75, 0],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0, 8, 0]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 3.5], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [8, 0, 0, 3.5], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 3.5], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [8, 0, 0, 3.5], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -25,12 +25,12 @@
 			"to": [13.25793, 8.75, -2.453],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [3.66793, 8, -2.453]},
 			"faces": {
-				"north": {"uv": [8, 0, 16, 3.5], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [16, 0, 8, 3.5], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [8, 0, 16, 3.5], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [16, 0, 8, 3.5], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -39,12 +39,12 @@
 			"to": [17.58538, 8.75, -3.31562],
 			"rotation": {"angle": -45, "axis": "y", "origin": [7.99538, 8, -3.31562]},
 			"faces": {
-				"north": {"uv": [0, 3.5, 8, 7], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [8, 3.5, 0, 7], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 3.5, 8, 7], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [8, 3.5, 0, 7], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -53,12 +53,12 @@
 			"to": [12.32261, 8.75, 7.13385],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [12.32261, 8, -2.45615]},
 			"faces": {
-				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [8, 3.5, 16, 7], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [16, 3.5, 8, 7], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [8, 3.5, 16, 7], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [16, 3.5, 8, 7], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -67,12 +67,12 @@
 			"to": [15.99247, 8.75, 9.58347],
 			"rotation": {"angle": 0, "axis": "y", "origin": [15.99247, 8, -0.00653]},
 			"faces": {
-				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 7, 8, 10.5], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [8, 7, 0, 10.5], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 7, 8, 10.5], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [8, 7, 0, 10.5], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -81,12 +81,12 @@
 			"to": [18.44555, 8.75, 13.25102],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [18.44555, 8, 3.66102]},
 			"faces": {
-				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [8, 7, 16, 10.5], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [16, 7, 8, 10.5], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [8, 7, 16, 10.5], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [16, 7, 8, 10.5], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -95,12 +95,12 @@
 			"to": [19.30838, 8.75, 17.57815],
 			"rotation": {"angle": -45, "axis": "y", "origin": [19.30838, 8, 7.98815]},
 			"faces": {
-				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 10.5, 8, 14], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [8, 10.5, 0, 14], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 10.5, 8, 14], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [8, 10.5, 0, 14], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -109,12 +109,12 @@
 			"to": [12.03962, 8.75, 12.31608],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [18.44962, 8, 12.31608]},
 			"faces": {
-				"north": {"uv": [16, 10.5, 8, 14], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [8, 10.5, 16, 14], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [16, 10.5, 8, 14], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [8, 10.5, 16, 14], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -123,12 +123,12 @@
 			"to": [9.59, 8.75, 15.98594],
 			"rotation": {"angle": 0, "axis": "y", "origin": [16, 8, 15.98594]},
 			"faces": {
-				"north": {"uv": [8, 0, 0, 3.5], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 0, 8, 3.5], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [8, 0, 0, 3.5], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 0, 8, 3.5], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -137,12 +137,12 @@
 			"to": [5.92207, 8.75, 18.43894],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [12.33207, 8, 18.43894]},
 			"faces": {
-				"north": {"uv": [16, 0, 8, 3.5], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 3.5], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [16, 0, 8, 3.5], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 3.5], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -151,12 +151,12 @@
 			"to": [1.59462, 8.75, 19.30156],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8.00462, 8, 19.30156]},
 			"faces": {
-				"north": {"uv": [8, 3.5, 0, 7], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 3.5, 8, 7], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [8, 3.5, 0, 7], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 3.5, 8, 7], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -165,12 +165,12 @@
 			"to": [3.67739, 8.75, 12.03209],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [3.67739, 8, 18.44209]},
 			"faces": {
-				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [16, 3.5, 8, 7], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [8, 3.5, 16, 7], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [16, 3.5, 8, 7], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [8, 3.5, 16, 7], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -179,12 +179,12 @@
 			"to": [0.00753, 8.75, 9.58247],
 			"rotation": {"angle": 0, "axis": "y", "origin": [0.00753, 8, 15.99247]},
 			"faces": {
-				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [8, 7, 0, 10.5], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 7, 8, 10.5], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [8, 7, 0, 10.5], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 7, 8, 10.5], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -193,12 +193,12 @@
 			"to": [-2.44555, 8.75, 5.91492],
 			"rotation": {"angle": -22.5, "axis": "y", "origin": [-2.44555, 8, 12.32492]},
 			"faces": {
-				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [16, 7, 8, 10.5], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [8, 7, 16, 10.5], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [16, 7, 8, 10.5], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [8, 7, 16, 10.5], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -207,12 +207,12 @@
 			"to": [-3.30838, 8.75, 1.58779],
 			"rotation": {"angle": -45, "axis": "y", "origin": [-3.30838, 8, 7.99779]},
 			"faces": {
-				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [8, 10.5, 0, 14], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 10.5, 8, 14], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [8, 10.5, 0, 14], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 10.5, 8, 14], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		},
 		{
@@ -221,12 +221,12 @@
 			"to": [7.14038, 8.75, 3.66986],
 			"rotation": {"angle": 22.5, "axis": "y", "origin": [-2.44962, 8, 3.66986]},
 			"faces": {
-				"north": {"uv": [8, 10.5, 16, 14], "texture": "#0", "tintindex": 1},
-				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"south": {"uv": [16, 10.5, 8, 14], "texture": "#0", "tintindex": 1},
-				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1},
-				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 1}
+				"north": {"uv": [8, 10.5, 16, 14], "texture": "#0", "tintindex": 0},
+				"east": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"south": {"uv": [16, 10.5, 8, 14], "texture": "#0", "tintindex": 0},
+				"west": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"up": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0},
+				"down": {"uv": [0, 1, 0, 1], "texture": "#0", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/magic_fruit_cheriff.json
+++ b/assets/tusb/models/item/mob/magic_fruit_cheriff.json
@@ -96,12 +96,12 @@
 			"to": [16, 32, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 24, 8]},
 			"faces": {
-				"north": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -110,12 +110,12 @@
 			"to": [8, 32, 16],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 24, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/magic_vegetable_yasaosan.json
+++ b/assets/tusb/models/item/mob/magic_vegetable_yasaosan.json
@@ -12,12 +12,12 @@
 			"to": [8, 24, 12],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 0, 0, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -26,12 +26,12 @@
 			"to": [12, 24, 8],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{

--- a/assets/tusb/models/item/mob/nether_gate_of_nothingness.json
+++ b/assets/tusb/models/item/mob/nether_gate_of_nothingness.json
@@ -15,9 +15,9 @@
 			"to": [10, 12, 0.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -29,9 +29,9 @@
 			"to": [14, 12, 0.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -43,9 +43,9 @@
 			"to": [6, 12, 0.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -57,9 +57,9 @@
 			"to": [10, 12, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -71,9 +71,9 @@
 			"to": [14, 12, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -85,9 +85,9 @@
 			"to": [6, 12, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -99,9 +99,9 @@
 			"to": [10, 8, 0.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -113,9 +113,9 @@
 			"to": [14, 8, 0.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -127,9 +127,9 @@
 			"to": [6, 8, 0.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -141,9 +141,9 @@
 			"to": [10, 8, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -155,9 +155,9 @@
 			"to": [14, 8, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -169,9 +169,9 @@
 			"to": [6, 8, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -183,9 +183,9 @@
 			"to": [10, 16, 0.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -197,9 +197,9 @@
 			"to": [14, 16, 0.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -211,9 +211,9 @@
 			"to": [6, 16, 0.75],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -225,9 +225,9 @@
 			"to": [10, 16, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -239,9 +239,9 @@
 			"to": [14, 16, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -253,9 +253,9 @@
 			"to": [6, 16, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}

--- a/assets/tusb/models/item/mob/petit_blackfall.json
+++ b/assets/tusb/models/item/mob/petit_blackfall.json
@@ -72,7 +72,7 @@
 				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3"}
 			}
@@ -84,7 +84,7 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
 				"north": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
-				"east": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 1},
+				"east": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 0},
 				"south": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"west": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
@@ -99,7 +99,7 @@
 			"faces": {
 				"north": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"east": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
-				"south": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 1},
+				"south": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 0},
 				"west": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [16, 0, 0, 16], "rotation": 270, "texture": "#layer3"}
@@ -111,7 +111,7 @@
 			"to": [16.4864, 16.16, 16.16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
@@ -129,7 +129,7 @@
 				"east": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
+				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"}
 			}
 		},
@@ -144,7 +144,7 @@
 				"south": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"west": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
-				"down": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"down": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -156,7 +156,7 @@
 				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3"}
 			}
@@ -168,7 +168,7 @@
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
 				"north": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
-				"east": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 1},
+				"east": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 0},
 				"south": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"west": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
@@ -183,7 +183,7 @@
 			"faces": {
 				"north": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"east": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
-				"south": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 1},
+				"south": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 0},
 				"west": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [16, 0, 0, 16], "rotation": 270, "texture": "#layer3"}
@@ -195,7 +195,7 @@
 			"to": [16, 16, 16],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
@@ -213,7 +213,7 @@
 				"east": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
+				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"}
 			}
 		},
@@ -228,7 +228,7 @@
 				"south": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"west": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
-				"down": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"down": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -240,7 +240,7 @@
 				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3"}
 			}
@@ -252,7 +252,7 @@
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
 				"north": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
-				"east": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 1},
+				"east": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 0},
 				"south": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"west": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
@@ -267,7 +267,7 @@
 			"faces": {
 				"north": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"east": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
-				"south": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 1},
+				"south": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 0},
 				"west": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [16, 0, 0, 16], "rotation": 270, "texture": "#layer3"}
@@ -279,7 +279,7 @@
 			"to": [16, 16, 16],
 			"rotation": {"angle": -45, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
@@ -297,7 +297,7 @@
 				"east": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
+				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"}
 			}
 		},
@@ -312,7 +312,7 @@
 				"south": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"west": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
-				"down": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"down": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -324,7 +324,7 @@
 				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3"}
 			}
@@ -336,7 +336,7 @@
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
 				"north": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
-				"east": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 1},
+				"east": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 0},
 				"south": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"west": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
@@ -351,7 +351,7 @@
 			"faces": {
 				"north": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"east": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
-				"south": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 1},
+				"south": {"uv": [16, 0, 0, 16], "texture": "#layer1", "tintindex": 0},
 				"west": {"uv": [16, 0, 0, 16], "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [16, 0, 0, 16], "rotation": 270, "texture": "#layer3"}
@@ -363,7 +363,7 @@
 			"to": [16, 16, 16],
 			"rotation": {"angle": 45, "axis": "z", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
@@ -381,7 +381,7 @@
 				"east": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"south": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"west": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
-				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
+				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"}
 			}
 		},
@@ -396,7 +396,7 @@
 				"south": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"west": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
 				"up": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer3"},
-				"down": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1}
+				"down": {"uv": [16, 0, 0, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/pot_of_chaos.json
+++ b/assets/tusb/models/item/mob/pot_of_chaos.json
@@ -12,12 +12,12 @@
 			"to": [16, 16, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer0", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer0", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer0", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer0", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer0", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer0", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer0", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer0", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/predictor.json
+++ b/assets/tusb/models/item/mob/predictor.json
@@ -10,12 +10,12 @@
 			"to": [16, 32, 12.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-3, 0, 6]},
 			"faces": {
-				"north": {"uv": [4, 0, 12, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [4, 0, 5, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [12, 0, 4, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [12, 0, 11, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [12, 0, 4, 1], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [12, 15, 4, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [4, 0, 12, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [4, 0, 5, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [12, 0, 4, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [12, 0, 11, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [12, 0, 4, 1], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [12, 15, 4, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/thorn_trap_0.json
+++ b/assets/tusb/models/item/mob/thorn_trap_0.json
@@ -13,12 +13,12 @@
 			"to": [10, 0, 10],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -27,12 +27,12 @@
 			"to": [8, 6, 12],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -41,12 +41,12 @@
 			"to": [12, 6, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 6], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 6], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 8, 6], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 6], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 6], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 6], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 8, 6], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 6], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/thorn_trap_1.json
+++ b/assets/tusb/models/item/mob/thorn_trap_1.json
@@ -13,12 +13,12 @@
 			"to": [10, 0, 10],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -27,12 +27,12 @@
 			"to": [8, 24, 12],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -41,12 +41,12 @@
 			"to": [12, 24, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -55,12 +55,12 @@
 			"to": [8, 8, 12],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -69,12 +69,12 @@
 			"to": [12, 8, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/thorn_trap_2.json
+++ b/assets/tusb/models/item/mob/thorn_trap_2.json
@@ -13,12 +13,12 @@
 			"to": [10, 0, 10],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [0, 0, 8, 8], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -27,12 +27,12 @@
 			"to": [8, 32, 12],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -41,12 +41,12 @@
 			"to": [12, 32, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -55,12 +55,12 @@
 			"to": [8, 16, 12],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -69,12 +69,12 @@
 			"to": [12, 16, 8],
 			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [16, 16, 16, 16], "rotation": 180, "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/tnt.json
+++ b/assets/tusb/models/item/mob/tnt.json
@@ -24,12 +24,12 @@
 			"from": [0, 0, 0],
 			"to": [16, 16, 16],
 			"faces": {
-				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [16, 8, 8, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [8, 8, 0, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [16, 8, 8, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [8, 8, 0, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/trap_hole_0.json
+++ b/assets/tusb/models/item/mob/trap_hole_0.json
@@ -12,12 +12,12 @@
 			"to": [10, 0, 10],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "##layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "##layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "##layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "##layer1", "tintindex": 1},
-				"up": {"uv": [8, 0, 16, 8], "texture": "##layer1", "tintindex": 1},
-				"down": {"uv": [8, 0, 16, 8], "texture": "##layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "##layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "##layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "##layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "##layer1", "tintindex": 0},
+				"up": {"uv": [8, 0, 16, 8], "texture": "##layer1", "tintindex": 0},
+				"down": {"uv": [8, 0, 16, 8], "texture": "##layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/trap_hole_1.json
+++ b/assets/tusb/models/item/mob/trap_hole_1.json
@@ -12,12 +12,12 @@
 			"to": [10, 0, 10],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/trap_hole_2.json
+++ b/assets/tusb/models/item/mob/trap_hole_2.json
@@ -12,12 +12,12 @@
 			"to": [10, 0, 10],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [16, 16, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/mob/wriggling_sand.json
+++ b/assets/tusb/models/item/mob/wriggling_sand.json
@@ -395,9 +395,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3"}
 			}
@@ -408,9 +408,9 @@
 			"to": [12, 8, -4.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"}
@@ -423,9 +423,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"south": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#layer3"}
 			}
@@ -436,9 +436,9 @@
 			"to": [12, 8, 20.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 1},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer4", "tintindex": 0},
 				"west": {"uv": [0, 0, 16, 1], "texture": "#layer3"},
 				"up": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#layer3"},
 				"down": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#layer3"}

--- a/assets/tusb/models/item/tool/accessory/destructive_warning.json
+++ b/assets/tusb/models/item/tool/accessory/destructive_warning.json
@@ -1,8 +1,7 @@
 {
     "parent": "item/generated",
     "textures": {
-        "layer0": "tusb:item/common/clear_dots",
-        "layer1": "tusb:item/tool/accessory/warning",
-        "layer2": "tusb:item/aura/fire/negative_violet"
+        "layer0": "tusb:item/tool/accessory/warning",
+        "layer1": "tusb:item/aura/fire/negative_violet"
     }
 }

--- a/assets/tusb/models/item/tool/accessory/magic_square_crystal.json
+++ b/assets/tusb/models/item/tool/accessory/magic_square_crystal.json
@@ -168,12 +168,12 @@
 			"to": [3.6, 18.45, 12.4],
 			"rotation": {"angle": 0, "axis": "y", "origin": [3.6, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -181,12 +181,12 @@
 			"to": [5.79951, 29.50964, 12.4],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [5.79951, 23.76107, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [5.80043, -2.01231, 12.4],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [5.80043, -7.76131, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -207,12 +207,12 @@
 			"to": [12.4, 18.45, 3.6],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 3.6]},
 			"faces": {
-				"north": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -220,12 +220,12 @@
 			"to": [12.4, 29.50964, 5.79951],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 23.76107, 5.79951]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -233,12 +233,12 @@
 			"to": [12.4, -2.01231, 5.80043],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, -7.76131, 5.80043]},
 			"faces": {
-				"north": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -246,12 +246,12 @@
 			"to": [12.4, 18.45, 12.4],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 12.4]},
 			"faces": {
-				"north": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -259,12 +259,12 @@
 			"to": [12.4, 29.50964, 10.20049],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 23.76107, 10.20049]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -272,12 +272,12 @@
 			"to": [12.4, -2.01231, 10.19957],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, -7.76131, 10.19957]},
 			"faces": {
-				"north": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -285,12 +285,12 @@
 			"to": [12.4, 18.45, 12.4],
 			"rotation": {"angle": 0, "axis": "y", "origin": [12.4, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [8, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -298,12 +298,12 @@
 			"to": [10.20049, 29.50964, 12.4],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [10.20049, 23.76107, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -311,12 +311,12 @@
 			"to": [10.19957, -2.01231, 12.4],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [10.19957, -7.76131, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/tool/accessory/magic_square_crystal_v2.json
+++ b/assets/tusb/models/item/tool/accessory/magic_square_crystal_v2.json
@@ -116,12 +116,12 @@
 			"to": [5.79951, 19.0612, 12.4],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [5.79951, 13.31263, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -129,12 +129,12 @@
 			"to": [5.80043, 8.44004, 12.4],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [5.80043, 2.69103, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -142,12 +142,12 @@
 			"to": [12.4, 19.0612, 5.79951],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 13.31263, 5.79951]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -155,12 +155,12 @@
 			"to": [12.4, 8.44004, 5.80043],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 2.69103, 5.80043]},
 			"faces": {
-				"north": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -168,12 +168,12 @@
 			"to": [12.4, 19.0612, 10.20049],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 13.31263, 10.20049]},
 			"faces": {
-				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -181,12 +181,12 @@
 			"to": [12.4, 8.44004, 10.19957],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 2.69103, 10.19957]},
 			"faces": {
-				"north": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -194,12 +194,12 @@
 			"to": [10.20049, 19.0612, 12.4],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [10.20049, 13.31263, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 0, 8, 8], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		},
 		{
@@ -207,12 +207,12 @@
 			"to": [10.19957, 8.44004, 12.4],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [10.19957, 2.69103, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"west": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 1},
-				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 1}
+				"north": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"west": {"uv": [0, 8, 8, 16], "texture": "#layer1", "tintindex": 0},
+				"up": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#layer1", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/tool/accessory/warning.json
+++ b/assets/tusb/models/item/tool/accessory/warning.json
@@ -1,7 +1,6 @@
 {
     "parent": "item/generated",
     "textures": {
-        "layer0": "tusb:item/common/clear_dots",
-        "layer1": "tusb:item/tool/accessory/warning"
+        "layer0": "tusb:item/tool/accessory/warning"
     }
 }

--- a/assets/tusb/models/item/tool/key/key_block.json
+++ b/assets/tusb/models/item/tool/key/key_block.json
@@ -13,12 +13,12 @@
 			"to": [16, 16, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 1},
-				"up": {"uv": [16, 16, 0, 0], "texture": "#layer2", "tintindex": 1},
-				"down": {"uv": [16, 0, 0, 16], "texture": "#layer2", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer1", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer2", "tintindex": 0},
+				"up": {"uv": [16, 16, 0, 0], "texture": "#layer2", "tintindex": 0},
+				"down": {"uv": [16, 0, 0, 16], "texture": "#layer2", "tintindex": 0}
 			}
 		},
 		{
@@ -27,12 +27,12 @@
 			"to": [0, 16, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0}
 			}
 		},
 		{
@@ -41,12 +41,12 @@
 			"to": [0, 32, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0}
 			}
 		},
 		{
@@ -55,12 +55,12 @@
 			"to": [16, 32, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0}
 			}
 		},
 		{
@@ -69,12 +69,12 @@
 			"to": [32, 32, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0}
 			}
 		},
 		{
@@ -83,12 +83,12 @@
 			"to": [32, 16, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0}
 			}
 		},
 		{
@@ -97,12 +97,12 @@
 			"to": [32, 0, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0}
 			}
 		},
 		{
@@ -111,12 +111,12 @@
 			"to": [16, 0, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0}
 			}
 		},
 		{
@@ -125,12 +125,12 @@
 			"to": [0, 0, 16],
 			"rotation": {"angle": 0, "axis": "y", "origin": [-8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 1}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#layer3", "tintindex": 0}
 			}
 		}
 	],

--- a/assets/tusb/models/item/tool/key/key_block_key.json
+++ b/assets/tusb/models/item/tool/key/key_block_key.json
@@ -1,7 +1,6 @@
 {
     "parent": "tusb:parent/handheld_flipped/1x",
     "textures": {
-        "layer0": "tusb:item/common/clear_dots",
-        "layer1": "tusb:item/tool/key/key_block_key"
+        "layer0": "tusb:item/tool/key/key_block_key"
     }
 }


### PR DESCRIPTION
いままで`firework_star`の色設定を利用して、テクスチャの色を自由に設定する"無限色"という技術が使われていましたが、`custom_model_data`を使ってより汎用的に無限色テクスチャを利用できるようにしました。

花火の星のときは、`tintindex`が1でないとカラー設定が反映されませんでしたが、`custom_model_data`を使うことで、`tintindex`を0にしてカラー繁栄がされるようにしました。
そのため、`layer1`にあった無限色テクスチャは、`layer0`に変更になりました。このとき`layer0`に設定されていた透明テクスチャは削除しました。

また、3Dモデルに関しても`tintindex`の数値を0に変更しました。